### PR TITLE
Add web capture browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,21 @@ If you have Node.js and npm installed:
    ```
 4. Open [http://localhost:3000](http://localhost:3000) in your browser.
 
+## Web Capture Extension
+
+Capture text from any website and send it straight to Notion using the same
+configuration as the PDF reader.
+
+1. Open `chrome://extensions` and enable **Developer mode**.
+2. Click **Load unpacked** and select the `extension` folder.
+3. In the extension options set the URL where NotyPDF is running
+   (for example `http://localhost:3000`).
+4. Select text on any webpage, click the extension icon and press
+   **Send to Notion**.
+
+The extension will fetch your saved configuration from the app and create a new
+entry with the next identifier.
+
 ---
 
 ## License

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "NotyPDF Web Capture",
+  "description": "Capture selected text on any webpage and send it to NotyPDF/Notion.",
+  "version": "0.1",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Send selection to NotyPDF"
+  },
+  "options_page": "options.html"
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+body { font-family: Arial, sans-serif; min-width: 300px; padding: 10px; }
+input { width: 100%; }
+button { margin-top: 10px; }
+</style>
+</head>
+<body>
+<label>Backend URL:
+  <input id="backendUrl" type="text" placeholder="http://localhost:3000">
+</label>
+<button id="save">Save</button>
+<div id="status"></div>
+<script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.sync.get(['backendUrl'], ({ backendUrl }) => {
+    document.getElementById('backendUrl').value = backendUrl || 'http://localhost:3000';
+  });
+
+  document.getElementById('save').addEventListener('click', () => {
+    const url = document.getElementById('backendUrl').value;
+    chrome.storage.sync.set({ backendUrl: url }, () => {
+      const status = document.getElementById('status');
+      status.textContent = 'Saved!';
+      setTimeout(() => { status.textContent = ''; }, 1000);
+    });
+  });
+});

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+body { font-family: Arial, sans-serif; min-width: 300px; padding: 10px; }
+textarea { width: 100%; height: 100px; }
+button { margin-top: 10px; }
+</style>
+</head>
+<body>
+<textarea id="selection" placeholder="No text selected"></textarea>
+<button id="send">Send to Notion</button>
+<div id="status"></div>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,57 @@
+async function getSelectionText(tabId) {
+  const [{ result }] = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: () => window.getSelection().toString()
+  });
+  return result || '';
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const text = tab ? await getSelectionText(tab.id) : '';
+  document.getElementById('selection').value = text;
+});
+
+document.getElementById('send').addEventListener('click', () => {
+  const text = document.getElementById('selection').value.trim();
+  const statusEl = document.getElementById('status');
+  if (!text) {
+    statusEl.textContent = 'No text to send.';
+    return;
+  }
+  statusEl.textContent = 'Sending...';
+  chrome.storage.sync.get(['backendUrl'], async ({ backendUrl }) => {
+    const base = backendUrl || 'http://localhost:3000';
+    try {
+      const cfgRes = await fetch(`${base}/api/config`);
+      const cfg = await cfgRes.json();
+      if (!cfg.savedDatabaseIds || cfg.savedDatabaseIds.length === 0) {
+        statusEl.textContent = 'No database configured.';
+        return;
+      }
+      const dbId = cfg.savedDatabaseIds[0].databaseId;
+      const mapping = cfg.columnMappings[dbId];
+      if (!mapping) {
+        statusEl.textContent = 'Missing column mapping.';
+        return;
+      }
+      const notionConfig = {
+        databaseId: dbId,
+        ...mapping
+      };
+      const res = await fetch(`${base}/api/notion/save-text-with-identifier`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config: notionConfig, text })
+      });
+      const result = await res.json();
+      if (result.success) {
+        statusEl.textContent = `Saved with ID ${result.identifier}`;
+      } else {
+        statusEl.textContent = 'Error: ' + (result.error || 'Failed');
+      }
+    } catch (err) {
+      statusEl.textContent = 'Error: ' + err.message;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add browser extension to capture selected text from webpages
- allow configuring backend URL in extension options
- fetch stored NotyPDF configuration and send captured text to Notion
- document extension usage in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840602b2db8832eb8017180d7e66418