### PR TITLE
Handle PDF selections in extension popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,9 @@ configuration as the PDF reader.
    server through **NGINX Proxy Manager**, enter the external URL
    and provide the proxy authentication username and password.
 4. Select text on any webpage or PDF, click the extension icon and
-   press **Send to Notion**. You can also right‑click a selection
-   and choose **Send selection to NotyPDF**.
+   press **Send to Notion**. On PDF files the extension copies the
+   selection to the clipboard automatically. You can also right‑click a
+   selection and choose **Send selection to NotyPDF**.
 
 You can access the extension settings from the popup using the
 **Settings** button.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,15 @@
   "name": "NotyPDF Web Capture",
   "description": "Capture selected text on any webpage and send it to NotyPDF/Notion.",
   "version": "0.1",
-  "permissions": ["storage", "activeTab", "scripting", "contextMenus", "notifications"],
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting",
+    "contextMenus",
+    "notifications",
+    "clipboardRead",
+    "clipboardWrite"
+  ],
   "host_permissions": ["<all_urls>"],
   "icons": {
     "16": "logo.png",


### PR DESCRIPTION
## Summary
- support clipboard read/write in browser extension
- read selection from PDFs via clipboard when popup opens
- document clipboard behavior in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407da906c0832eb4e4579875f7c423