### PR TITLE
Improve help and README for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,15 +275,25 @@ configuration as the PDF reader.
 1. Open `chrome://extensions` and enable **Developer mode**.
 2. Click **Load unpacked** and select the `extension` folder.
 3. In the extension options set the URL where NotyPDF is running
-   (for example `http://localhost:3000`). If you're exposing the
-   server through **NGINX Proxy Manager**, enter the external URL
-   and provide the proxy authentication username and password.
+   (for example `http://localhost:3000`). If you started the app with
+   Docker Compose the address is `http://localhost:5026`. If you're
+   exposing the server through **NGINX Proxy Manager**, enter the
+   external URL and provide the proxy authentication username and
+   password.
 4. Select text on any webpage or PDF, click the extension icon and
-   press **Send to Notion**. You can also right‑click a selection
-   and choose **Send selection to NotyPDF**.
+   press **Send to Notion**. If nothing is selected the popup will use
+   the text currently copied to your clipboard. You can also right‑click
+   a selection and choose **Send selection to NotyPDF**.
 
-You can access the extension settings from the popup using the
-**Settings** button.
+You can access the extension settings directly inside the popup
+using the **Settings** button. A new **Help** button explains how
+the extension works. Use the arrows within the popup to return to
+the main screen after viewing the settings or help.
+
+When a PDF is opened with Chrome's built-in viewer the extension
+cannot read the selection when you open the popup. Use the
+right-click menu option **Send selection to NotyPDF** or copy the
+text first so the popup can read it from the clipboard.
 
 Using a reverse proxy makes the extension work from any browser and
 lets you add references directly to your Notion setup even when the

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -39,11 +39,35 @@
 </style>
 </head>
 <body>
-<textarea id="selection" placeholder="No text selected"></textarea>
-<input id="identifierPattern" type="text" placeholder="Identifier pattern (optional)" />
-<button id="send">Send to Notion</button>
-<button id="openOptions">Settings</button>
-<div id="status"></div>
+<div id="mainScreen">
+  <textarea id="selection" placeholder="No text selected"></textarea>
+  <input id="identifierPattern" type="text" placeholder="Identifier pattern (optional)" />
+  <button id="send">Send to Notion</button>
+  <button id="openOptions">Settings</button>
+  <button id="openHelp">Help</button>
+  <div id="status"></div>
+</div>
+
+<div id="optionsScreen" style="display:none;">
+  <button id="backFromOptions">&larr; Back</button>
+  <label>Backend URL:
+    <input id="backendUrl" type="text" placeholder="http://localhost:3000">
+  </label>
+  <label>Username:
+    <input id="backendUser" type="text" placeholder="user">
+  </label>
+  <label>Password:
+    <input id="backendPass" type="password" placeholder="password">
+  </label>
+  <button id="saveOptions">Save</button>
+  <button id="testConnection">Test Connection</button>
+  <div id="optionsStatus"></div>
+</div>
+
+<div id="helpScreen" style="display:none; max-height:250px; overflow-y:auto;">
+  <button id="backFromHelp">&larr; Back</button>
+  <div id="helpContent"></div>
+</div>
 <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -11,7 +11,14 @@ async function getSelectionText(tabId) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const text = tab ? await getSelectionText(tab.id) : '';
+  let text = tab ? await getSelectionText(tab.id) : '';
+  if (!text) {
+    try {
+      text = await navigator.clipboard.readText();
+    } catch (e) {
+      /* ignore */
+    }
+  }
   document.getElementById('selection').value = text;
   if (tab && /\.pdf($|\?)/i.test(tab.url || '')) {
     document.getElementById('status').textContent = 'PDF detected';
@@ -88,6 +95,73 @@ document.getElementById('send').addEventListener('click', () => {
   });
 });
 
+function showScreen(id) {
+  document.getElementById('mainScreen').style.display = id === 'main' ? 'block' : 'none';
+  document.getElementById('optionsScreen').style.display = id === 'options' ? 'block' : 'none';
+  document.getElementById('helpScreen').style.display = id === 'help' ? 'block' : 'none';
+}
+
 document.getElementById('openOptions').addEventListener('click', () => {
-  chrome.runtime.openOptionsPage();
+  chrome.storage.sync.get(['backendUrl','backendUser','backendPass'], ({ backendUrl, backendUser, backendPass }) => {
+    document.getElementById('backendUrl').value = backendUrl || 'http://localhost:3000';
+    document.getElementById('backendUser').value = backendUser || '';
+    document.getElementById('backendPass').value = backendPass || '';
+    document.getElementById('optionsStatus').textContent = '';
+    showScreen('options');
+  });
+});
+
+document.getElementById('backFromOptions').addEventListener('click', () => {
+  showScreen('main');
+});
+
+document.getElementById('saveOptions').addEventListener('click', () => {
+  const url = document.getElementById('backendUrl').value;
+  const user = document.getElementById('backendUser').value;
+  const pass = document.getElementById('backendPass').value;
+  chrome.storage.sync.set({ backendUrl: url, backendUser: user, backendPass: pass }, () => {
+    const status = document.getElementById('optionsStatus');
+    status.textContent = 'Saved!';
+    setTimeout(() => { status.textContent = ''; }, 1000);
+  });
+});
+
+document.getElementById('testConnection').addEventListener('click', async () => {
+  const url = document.getElementById('backendUrl').value;
+  const user = document.getElementById('backendUser').value;
+  const pass = document.getElementById('backendPass').value;
+  const headers = {};
+  if (user && pass) {
+    headers['Authorization'] = `Basic ${btoa(`${user}:${pass}`)}`;
+  }
+  try {
+    const res = await fetch(`${url}/api/notion/test-connection`, { headers });
+    const data = await res.json();
+    const status = document.getElementById('optionsStatus');
+    if (data.success) {
+      status.textContent = 'Connection successful';
+    } else {
+      status.textContent = 'Failed: ' + (data.message || 'Error');
+    }
+  } catch (e) {
+    document.getElementById('optionsStatus').textContent = 'Error: ' + e.message;
+  }
+});
+
+document.getElementById('openHelp').addEventListener('click', () => {
+  const help = `
+<p><b>How it works</b></p>
+<ol>
+  <li>Open <b>Settings</b> and enter the URL where NotyPDF is running. If you started the app with Docker Compose use <code>http://localhost:5026</code>. Add the proxy username and password if you use a reverse proxy.</li>
+  <li>Select text on any web page and open the popup to send it directly to Notion. If nothing is selected the popup tries to use the text you copied to the clipboard.</li>
+  <li>If a PDF is viewed with Chrome's built-in reader, select the text and use the right-click menu item <i>Send selection to NotyPDF</i>, or copy the text first and open the popup.</li>
+  <li>A reverse proxy (for example NGINX Proxy Manager) lets the extension connect from any browser even when the server isn't local.</li>
+</ol>
+<p>Use the arrows to move back after visiting Settings or this Help page.</p>`;
+  document.getElementById('helpContent').innerHTML = help;
+  showScreen('help');
+});
+
+document.getElementById('backFromHelp').addEventListener('click', () => {
+  showScreen('main');
 });


### PR DESCRIPTION
## Summary
- mention Docker's localhost port in README
- explain clipboard fallback in README and help screen
- fetch text from clipboard in popup

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407dcf49d0832eaa23498ab5cb868a