### PR TITLE
Add integrated help and settings screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ configuration as the PDF reader.
    selection and choose **Send selection to NotyPDF**.
 
 You can access the extension settings from the popup using the
-**Settings** button.
+**Settings** button. A **Help** button is also available with
+instructions on configuring the connection, using the extension with
+PDFs and the Docker URL note.
 
 Using a reverse proxy makes the extension work from any browser and
 lets you add references directly to your Notion setup even when the

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -39,11 +39,47 @@
 </style>
 </head>
 <body>
-<textarea id="selection" placeholder="No text selected"></textarea>
-<input id="identifierPattern" type="text" placeholder="Identifier pattern (optional)" />
-<button id="send">Send to Notion</button>
-<button id="openOptions">Settings</button>
-<div id="status"></div>
+<div id="main-screen">
+  <textarea id="selection" placeholder="No text selected"></textarea>
+  <input id="identifierPattern" type="text" placeholder="Identifier pattern (optional)" />
+  <button id="send">Send to Notion</button>
+  <button id="openSettings">Settings</button>
+  <button id="openHelp">Help</button>
+  <div id="status"></div>
+</div>
+
+<div id="settings-screen" style="display:none;">
+  <label>Backend URL:
+    <input id="backendUrl" type="text" placeholder="http://localhost:3000">
+  </label>
+  <label>Username:
+    <input id="backendUser" type="text" placeholder="user">
+  </label>
+  <label>Password:
+    <input id="backendPass" type="password" placeholder="password">
+  </label>
+  <button id="saveSettings">Save</button>
+  <button id="testConnection">Test Connection</button>
+  <button id="backFromSettings">Back</button>
+  <div id="settingsStatus"></div>
+</div>
+
+<div id="help-screen" style="display:none;">
+  <h3>How it works</h3>
+  <p>Use this extension to send selected text from any page or PDF viewer to your NotyPDF server.</p>
+  <h4>Configuration</h4>
+  <ul>
+    <li>Open <b>Settings</b> to set the server URL.</li>
+    <li>If the server is exposed through a reverse proxy such as Nginx Proxy Manager, enter the external URL and any authentication credentials.</li>
+    <li>Provide username and password if your proxy requires them.</li>
+  </ul>
+  <h4>PDF Selection</h4>
+  <p>When viewing a PDF, copy the text to the clipboard before sending. Chrome cannot directly read selections inside PDFs.</p>
+  <h4>Note</h4>
+  <p>If running NotyPDF in a local Docker container, connect to <code>http://localhost:5026</code> instead of <code>http://localhost:3000</code>.</p>
+  <button id="backFromHelp">Back</button>
+</div>
+
 <script src="popup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include settings and help sections in the popup
- explain configuration, PDF selections and Docker URL in help screen
- update README with mention of the Help button

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840847e95f4832e9956d4c05f9ae6b6