### PR TITLE
Upgrade mobile app to Expo SDK 53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # Build output
 build/
 
+# Mobile backend build output
+mobile/backend/dist/
+
 # Environment variables
 .env
 .env.*

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { SafeAreaView, StyleSheet, View, Button, TextInput, ScrollView, Text } from 'react-native';
+import * as DocumentPicker from 'expo-document-picker';
+import Pdf from 'react-native-pdf';
+import notionService from './services/notionService';
+import { NotionConfig } from './types';
+
+export default function App() {
+  const [pdfUri, setPdfUri] = useState<string | null>(null);
+  const [selectedText, setSelectedText] = useState('');
+  const [databaseId, setDatabaseId] = useState('');
+  const [identifierColumn, setIdentifierColumn] = useState('');
+  const [textColumn, setTextColumn] = useState('');
+  const [status, setStatus] = useState('');
+
+  const pickPdf = async () => {
+    const result = await DocumentPicker.getDocumentAsync({ type: 'application/pdf' });
+    if (result.type === 'success') {
+      setPdfUri(result.uri);
+    }
+  };
+
+  const sendToNotion = async () => {
+    const config: NotionConfig = {
+      databaseId,
+      identifierColumn,
+      textColumn,
+      annotationColumn: '',
+      pageColumn: '',
+      identifierPattern: '',
+      annotation: '',
+      pageNumber: '',
+      documentIdInsertionColumn: '',
+      enableDocumentIdInsertion: false
+    };
+
+    try {
+      const res = await notionService.saveTextWithIdentifier(config, selectedText);
+      if (res.success) {
+        setStatus('Saved with ID: ' + res.identifier);
+      } else {
+        setStatus('Failed to save text');
+      }
+    } catch (err: any) {
+      setStatus('Error: ' + err.message);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Button title="Pick PDF" onPress={pickPdf} />
+      {pdfUri && (
+        <View style={styles.viewer}>
+          <Pdf source={{ uri: pdfUri }} style={{ flex: 1 }} />
+        </View>
+      )}
+      <ScrollView contentContainerStyle={styles.form}>
+        <TextInput
+          placeholder="Selected text"
+          multiline
+          value={selectedText}
+          onChangeText={setSelectedText}
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Database ID"
+          value={databaseId}
+          onChangeText={setDatabaseId}
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Identifier column"
+          value={identifierColumn}
+          onChangeText={setIdentifierColumn}
+          style={styles.input}
+        />
+        <TextInput
+          placeholder="Text column"
+          value={textColumn}
+          onChangeText={setTextColumn}
+          style={styles.input}
+        />
+        <Button title="Send to Notion" onPress={sendToNotion} />
+        {status ? <Text style={styles.status}>{status}</Text> : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  viewer: { flex: 1, marginTop: 10 },
+  form: { padding: 20 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 10, marginTop: 10 },
+  status: { marginTop: 10 }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,24 @@
+# NotyPDF Mobile (React Native)
+
+This directory contains an experimental React Native version of **NotyPDF** targeting iOS and Android. It bundles a lightweight backend so the mobile app can run independently of the main project.
+
+The mobile client now relies on **Expo SDK&nbsp;53.0.0**.
+
+## Getting Started
+
+1. Install dependencies (requires `npm` and the Expo CLI):
+   ```sh
+   npm install
+   ```
+2. Build and start the embedded backend:
+   ```sh
+   npm run backend
+   ```
+   This will compile and launch a small Express server on port `4000`.
+3. In a separate terminal start the Expo development server:
+   ```sh
+   npm run start
+   ```
+   Use `npm run ios` or `npm run android` to open the app on a simulator or device.
+
+The app allows you to pick a PDF file from your device, enter the desired Notion configuration and send selected text to the embedded backend.

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/backend/package.json
+++ b/mobile/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "notypdf-mobile-backend",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.5"
+  }
+}

--- a/mobile/backend/server.ts
+++ b/mobile/backend/server.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// simple in-memory store for saved notes
+let counter = 1;
+
+app.get('/ping', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.post('/notion/save-text-with-identifier', (req, res) => {
+  const { config, text } = req.body;
+  if (!config || !text) {
+    return res.status(400).json({ success: false, error: 'Missing config or text' });
+  }
+  const identifier = `MOB${String(counter).padStart(3, '0')}`;
+  counter += 1;
+  res.json({ success: true, identifier });
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Mobile backend running on port ${PORT}`);
+});

--- a/mobile/backend/tsconfig.json
+++ b/mobile/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["server.ts"]
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "notypdf-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "backend": "cd backend && npm install --silent && npm run build && npm start"
+  },
+  "dependencies": {
+    "expo": "~53.0.0",
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "expo-document-picker": "~14.0.0",
+    "react-native-pdf": "^6.6.2",
+    "axios": "^1.9.0",
+    "react-native-webview": "^13.7.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "typescript": "^4.9.5"
+  }
+}

--- a/mobile/services/notionService.ts
+++ b/mobile/services/notionService.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { NotionConfig } from '../types';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+
+export async function saveTextWithIdentifier(config: NotionConfig, text: string): Promise<{success: boolean; identifier: string}> {
+  const response = await axios.post(`${API_BASE_URL}/notion/save-text-with-identifier`, { config, text });
+  return response.data;
+}
+
+export default { saveTextWithIdentifier };

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "lib": ["dom", "es6"],
+    "jsx": "react",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/mobile/types.ts
+++ b/mobile/types.ts
@@ -1,0 +1,72 @@
+export interface SavedDatabaseId {
+  id: string;
+  name: string;
+  databaseId: string;
+  createdAt: Date;
+}
+
+export interface NotionConfig {
+  databaseId: string;
+  identifierColumn: string;
+  textColumn: string;
+  annotationColumn: string;
+  pageColumn: string;
+  identifierPattern: string;
+  annotation: string;
+  pageNumber: string;
+  documentIdInsertionColumn: string; // New: column for document identifier insertion
+  enableDocumentIdInsertion?: boolean; // New: flag to enable document ID insertion
+}
+
+export interface NotionProperty {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface NotionPage {
+  id: string;
+  properties: Record<string, any>;
+}
+
+export type OpenAIModel = 'gpt-4.1' | 'gpt-4.1-mini' | 'gpt-4o' | 'gpt-4o-mini';
+export type OpenRouterModel =
+  | 'google/gemma-3-27b-it:free'
+  | 'google/gemini-2.0-flash-exp:free'
+  | 'meta-llama/llama-4-maverick:free'
+  | 'meta-llama/llama-4-scout:free'
+  | 'deepseek/deepseek-chat-v3-0324:free'
+  | 'qwen/qwen3-32b:free'
+  | 'mistralai/mistral-small-3.1-24b-instruct:free';
+export type GeminiModel = 'gemini-2.0-pro' | 'gemini-2.0-flash';
+export type DeepSeekModel = 'deepseek-chat' | 'deepseek-reasoner';
+export type TranslationProvider = 'openai' | 'openrouter' | 'gemini' | 'deepseek' | '';
+export type TranslationModel = OpenAIModel | OpenRouterModel | GeminiModel | DeepSeekModel | '';
+
+export interface TranslationConfig {
+  enabled: boolean;
+  provider: TranslationProvider;
+  model: TranslationModel;
+  targetLanguage: string;
+  sendMode: 'original' | 'translated';
+}
+
+export interface TagMapping {
+  contextColumns: string[];
+  tagColumns: string[][];
+  aiConfig?: {
+    provider: TranslationProvider;
+    model: TranslationModel;
+  };
+  prompts?: string[];
+  language?: string; // Added for per-database language selection
+  maximumTags?: number; // Número máximo de tags por entrada
+}
+
+// Update AppConfig to use TagMapping
+export interface AppConfig {
+  savedDatabaseIds: SavedDatabaseId[];
+  columnMappings: Record<string, Partial<NotionConfig>>;
+  tagMappings?: Record<string, TagMapping>;
+  lastUpdated: string;
+}


### PR DESCRIPTION
## Summary
- bump Expo to 53.0.0 in `mobile/package.json`
- update example dependency versions
- note the new SDK version in the mobile README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d0e2941c832e9e1ddf2144c5421a