### PR TITLE
Fix workspace path and save viewer uploads

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -41,7 +41,11 @@ notion = Client(auth=NOTION_API_KEY)
 CONFIG_FILE_PATH = '/app/data/config.json'
 
 # Document storage path
-WORKSPACE_PATH = '/myworkspace'
+# Use environment variable or default to a local "myworkspace" folder
+WORKSPACE_PATH = os.environ.get(
+    "WORKSPACE_PATH",
+    os.path.join(os.getcwd(), "myworkspace"),
+)
 
 # Ensure data directory exists
 os.makedirs(os.path.dirname(CONFIG_FILE_PATH), exist_ok=True)

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -3,6 +3,7 @@ import { Document, Page, pdfjs } from 'react-pdf';
 import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, Layout, Languages, Bookmark } from 'lucide-react';
 import { TranslationConfig } from '../types';
 import { translateTextStreaming } from '../services/translationService';
+import { fileService } from '../services/fileService';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
 
@@ -60,15 +61,25 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
     console.error('PDF load error:', error);
   }
 
+  async function uploadAndLoadFile(selectedFile: File) {
+    if (selectedFile.type !== 'application/pdf') {
+      setError('Please select a valid PDF file');
+      return;
+    }
+    try {
+      await fileService.uploadFile(selectedFile);
+      setError('');
+    } catch (err) {
+      console.error('Error uploading file:', err);
+      setError('Failed to upload file to server');
+    }
+    onFileUpload(selectedFile);
+  }
+
   function handleFileInputChange(event: React.ChangeEvent<HTMLInputElement>) {
     const selectedFile = event.target.files?.[0];
     if (selectedFile) {
-      if (selectedFile.type === 'application/pdf') {
-        onFileUpload(selectedFile);
-        setError('');
-      } else {
-        setError('Please select a valid PDF file');
-      }
+      uploadAndLoadFile(selectedFile);
     }
   }
 
@@ -106,12 +117,7 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
     const files = event.dataTransfer.files;
     if (files.length > 0) {
       const droppedFile = files[0];
-      if (droppedFile.type === 'application/pdf') {
-        onFileUpload(droppedFile);
-        setError('');
-      } else {
-        setError('Please drop a valid PDF file');
-      }
+      uploadAndLoadFile(droppedFile);
     }
   }
 


### PR DESCRIPTION
## Summary
- save viewer uploads to the server
- allow configuring `WORKSPACE_PATH` via environment variable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab75f7dc832eb62ee3158fd8bafa