### PR TITLE
Implement bookmark toggle and add drag-and-drop uploads

### DIFF
--- a/src/components/DocumentManagerModal.css
+++ b/src/components/DocumentManagerModal.css
@@ -174,6 +174,26 @@
   box-shadow: none;
 }
 
+.drop-area {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  color: #007acc;
+  border: 2px dashed #007acc;
+  background: #f9fafb;
+  transition: all 0.2s ease;
+}
+
+.drop-area.drag-over {
+  background: #e0f2ff;
+}
+
 /* Disabled State */
 .upload-button.disabled {
   opacity: 0.6;

--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -29,6 +29,7 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
     total: number;
     currentFileName: string;
   } | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   // Load documents from server on component mount
   useEffect(() => {
@@ -143,6 +144,25 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
       setIsLoading(false);
       setUploadProgress('');
       setUploadDetails(null);
+    }
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = async (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length > 0) {
+      await handleMultipleFiles(files);
     }
   };
 
@@ -301,20 +321,28 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
               disabled={isLoading}
               multiple
             />
-            <label htmlFor="file-upload" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
-              <Upload size={20} />
-              <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
-            </label>
-            <button
-              className="clear-all-button"
-              onClick={handleClearAllFiles}
-              disabled={isLoading || documents.length === 0}
-              title={documents.length === 0 ? "No files to clear" : `Clear all ${documents.length} files`}
-            >
-              <Trash2 size={20} />
-              <span>Clear All Files</span>
-            </button>
+          <label htmlFor="file-upload" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
+            <Upload size={20} />
+            <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
+          </label>
+          <button
+            className="clear-all-button"
+            onClick={handleClearAllFiles}
+            disabled={isLoading || documents.length === 0}
+            title={documents.length === 0 ? "No files to clear" : `Clear all ${documents.length} files`}
+          >
+            <Trash2 size={20} />
+            <span>Clear All Files</span>
+          </button>
+          <div
+            className={`drop-area ${isDragOver ? 'drag-over' : ''}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            Drop files here
           </div>
+        </div>
           {uploadProgress && (
             <div className="upload-progress">
               {uploadProgress}

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -18,6 +18,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
   const [showClearAllConfirm, setShowClearAllConfirm] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<string>('');
   const [uploadDetails, setUploadDetails] = useState<{ current: number; total: number; currentFileName: string; } | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
 
   useEffect(() => {
     loadDocuments();
@@ -127,6 +128,25 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
       setIsLoading(false);
       setUploadProgress('');
       setUploadDetails(null);
+    }
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = async (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragOver(false);
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length > 0) {
+      await handleMultipleFiles(files);
     }
   };
 
@@ -265,20 +285,28 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
               disabled={isLoading}
               multiple
             />
-            <label htmlFor="file-upload-inline" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
-              <Upload size={20} />
-              <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
-            </label>
-            <button
-              className="clear-all-button"
-              onClick={handleClearAllFiles}
-              disabled={isLoading || documents.length === 0}
-              title={documents.length === 0 ? 'No files to clear' : `Clear all ${documents.length} files`}
-            >
-              <Trash2 size={20} />
-              <span>Clear All Files</span>
-            </button>
+          <label htmlFor="file-upload-inline" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
+            <Upload size={20} />
+            <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
+          </label>
+          <button
+            className="clear-all-button"
+            onClick={handleClearAllFiles}
+            disabled={isLoading || documents.length === 0}
+            title={documents.length === 0 ? 'No files to clear' : `Clear all ${documents.length} files`}
+          >
+            <Trash2 size={20} />
+            <span>Clear All Files</span>
+          </button>
+          <div
+            className={`drop-area ${isDragOver ? 'drag-over' : ''}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            Drop files here
           </div>
+        </div>
           {uploadProgress && (
             <div className="upload-progress">
               {uploadProgress}

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -262,11 +262,22 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
 
   function handleBookmarkPage() {
     if (file) {
-      localStorage.setItem(`bookmark_${file.name}`, pageNumber.toString());
-      setBookmarkedPage(pageNumber);
-      configService.saveBookmark(file.name, pageNumber).catch(err =>
-        console.error('Error saving bookmark:', err)
-      );
+      const bookmarkKey = `bookmark_${file.name}`;
+      const isBookmarked = bookmarkedPage === pageNumber;
+
+      if (isBookmarked) {
+        localStorage.removeItem(bookmarkKey);
+        setBookmarkedPage(null);
+        configService.removeBookmark(file.name).catch(err =>
+          console.error('Error removing bookmark:', err)
+        );
+      } else {
+        localStorage.setItem(bookmarkKey, pageNumber.toString());
+        setBookmarkedPage(pageNumber);
+        configService.saveBookmark(file.name, pageNumber).catch(err =>
+          console.error('Error saving bookmark:', err)
+        );
+      }
     }
   }
 

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -162,6 +162,17 @@ class ConfigService {
       console.error('Error saving bookmark:', error);
     }
   }
+
+  async removeBookmark(fileName: string): Promise<void> {
+    try {
+      const config = await this.getConfig();
+      const updated = { ...(config.bookmarks || {}) };
+      delete updated[fileName];
+      await this.updateConfig({ bookmarks: updated });
+    } catch (error) {
+      console.error('Error removing bookmark:', error);
+    }
+  }
 }
 
 const configService = new ConfigService();


### PR DESCRIPTION
## Summary
- toggle bookmarks when clicking the bookmark button again
- expose bookmark removal in `configService`
- enable file drag & drop in document manager modal and panel
- style the drop area with same height and style as the upload buttons

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b5692fec832eacb06ac74f5a5c50