### PR TITLE
Add button to close PDF

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,10 @@ function App() {
     setPdfFile(file);
   }, []);
 
+  const handleCloseFile = useCallback(() => {
+    setPdfFile(null);
+  }, []);
+
   const handleTextSelection = useCallback(async (text: string) => {
     setSelectedText(text);
     if (text.trim()) {
@@ -332,6 +336,7 @@ function App() {
               translationConfig={translationConfig}
               onFullscreenChange={handleFullscreenChange}
               onPageTextExtracted={handlePageTextExtracted}
+              onFileClose={handleCloseFile}
             />
           </main>
         </div>

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, Layout, Languages, Bookmark } from 'lucide-react';
+import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, Layout, Languages, Bookmark, X } from 'lucide-react';
 import DocumentManagerPanel from './DocumentManagerPanel';
 import { TranslationConfig } from '../types';
 import configService from '../services/configService';
@@ -16,9 +16,10 @@ interface PDFViewerProps {
   translationConfig: TranslationConfig;
   onFullscreenChange?: (isFullscreen: boolean, container: HTMLElement | null) => void;
   onPageTextExtracted?: (text: string, pageNumber: number) => void;
+  onFileClose?: () => void;
 }
 
-const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelection, translationConfig, onFullscreenChange, onPageTextExtracted }) => {
+const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelection, translationConfig, onFullscreenChange, onPageTextExtracted, onFileClose }) => {
   const [numPages, setNumPages] = useState<number>(0);
   const [pageNumber, setPageNumber] = useState<number>(1);
   const [error, setError] = useState<string>('');
@@ -197,6 +198,16 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
       if (document.exitFullscreen) {
         document.exitFullscreen();
       }
+    }
+  }
+
+  function handleCloseFile() {
+    setNumPages(0);
+    setPageNumber(1);
+    setError('');
+    setBookmarkedPage(null);
+    if (onFileClose) {
+      onFileClose();
     }
   }
 
@@ -527,10 +538,18 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                   >
                     <Layout size={14} />
                   </button>
-                  <button 
-                    className="btn btn-compact btn-secondary btn-same-size" 
+                  <button
+                    className="btn btn-compact btn-secondary btn-same-size"
                     style={{ minWidth: 32, minHeight: 32 }}
-                    onClick={openFileDialog} 
+                    onClick={handleCloseFile}
+                    title="Close File"
+                  >
+                    <X size={14} />
+                  </button>
+                  <button
+                    className="btn btn-compact btn-secondary btn-same-size"
+                    style={{ minWidth: 32, minHeight: 32 }}
+                    onClick={openFileDialog}
                     title="Change File"
                   >
                     <Upload size={14} />


### PR DESCRIPTION
## Summary
- add X button to PDF toolbar
- allow closing PDF via App

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b885c43c832e9bb9e80b0e3b4c9e