### PR TITLE
Fix duplicate uploads in inline document manager

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -88,6 +88,11 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
     onFileUpload(selectedFile);
   }
 
+  // Helper used by DocumentManagerPanel which already uploaded the file
+  function loadFileOnly(selectedFile: File) {
+    onFileUpload(selectedFile);
+  }
+
   function handleFileInputChange(event: React.ChangeEvent<HTMLInputElement>) {
     const selectedFile = event.target.files?.[0];
     if (selectedFile) {
@@ -335,7 +340,7 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
   if (!file) {
     return (
       <div className="pdf-container" onDragOver={handleDragOver} onDragLeave={handleDragLeave} onDrop={handleDrop}>
-        <DocumentManagerPanel onFileUpload={uploadAndLoadFile} currentFile={null} />
+        <DocumentManagerPanel onFileUpload={loadFileOnly} currentFile={null} />
         <input
           ref={fileInputRef}
           type="file"


### PR DESCRIPTION
## Summary
- avoid uploading a file twice when selecting from the inline document manager

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba008b9c832eb08a7b484731a5c5