### PR TITLE
Fix config persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Thumbs.db
 __pycache__/
 *.pyc
 
+# Local data and workspace directories
+data/
+myworkspace/
+
 # VSCode settings
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -249,9 +249,23 @@ If you have never used Docker before, follow these steps:
    ```sh
    docker-compose up --build
    ```
-6. Wait until you see a message that the server is running.
-7. Open your web browser and go to [http://localhost:5026](http://localhost:5026)
+6. The first time you run it, two folders (`data` and `myworkspace`) will be
+   created next to the `docker-compose.yml` file. All configuration is stored in
+   the `data` folder so it will remain even if you update or recreate the
+   container.
+7. Wait until you see a message that the server is running.
+8. Open your web browser and go to [http://localhost:5026](http://localhost:5026)
 
+If you prefer to run the container manually with `docker run` instead of using
+Docker Compose, make sure to mount the same folders so your configuration is
+preserved:
+```sh
+docker run -d \
+  -p 5026:5026 \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/myworkspace:/myworkspace \
+  --name notypdf drakonis96/notypdf:latest
+```
 ### 4. Alternative: Run the React Server Directly (For Developers)
 
 If you have Node.js and npm installed:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,14 +13,11 @@ services:
       - NOTION_API_KEY=${NOTION_API_KEY}
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - notypdf-data:/app/data
+      - ./data:/app/data
       - ./myworkspace:/myworkspace
     restart: unless-stopped
     networks:
       - default
-
-volumes:
-  notypdf-data:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,11 @@ services:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
       - NOTION_API_KEY=${NOTION_API_KEY}
     volumes:
-      - notypdf-data:/app/data
+      - ./data:/app/data
       - ./myworkspace:/myworkspace
     restart: unless-stopped
     networks:
       - default
-
-volumes:
-  notypdf-data:
 
 networks:
   default:

--- a/gitignore
+++ b/gitignore
@@ -21,6 +21,10 @@ Thumbs.db
 __pycache__/
 *.pyc
 
+# Local data and workspace directories
+data/
+myworkspace/
+
 # VSCode settings
 .vscode/
 


### PR DESCRIPTION
## Summary
- mount `data` to store configuration across container updates
- ignore data and workspace directories
- document persistent storage in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb04ae74832ea4d90e3da241fe13