### PR TITLE
Add chat mode with modal for PDF viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ConfigModal from './components/ConfigModal';
 import FloatingActionButton from './components/FloatingActionButton';
 import DocumentManagerModal from './components/DocumentManagerModal';
 import TranslationModal from './components/TranslationModal'; // Import TranslationModal
+import ChatModal from './components/ChatModal';
 import { NotionConfig, TranslationConfig, SavedDatabaseId } from './types';
 import configService from './services/configService';
 import notionService from './services/notionService';
@@ -38,6 +39,9 @@ function App() {
     targetLanguage: '',
     sendMode: 'original',
   });
+  const [isChatMode, setIsChatMode] = useState<boolean>(false);
+  const [showChatModal, setShowChatModal] = useState<boolean>(false);
+  const [chatSelectedText, setChatSelectedText] = useState<string>('');
 
   // State for App-level Translation Modal
   const [isAppTranslationModalOpen, setIsAppTranslationModalOpen] = useState<boolean>(false);
@@ -104,6 +108,17 @@ function App() {
   }, []);
 
   const handleTextSelection = useCallback(async (text: string) => {
+    if (isChatMode) {
+      setChatSelectedText(text);
+      if (text.trim()) {
+        setShowChatModal(true);
+        if (window.getSelection) {
+          window.getSelection()?.removeAllRanges();
+        }
+      }
+      return;
+    }
+
     setSelectedText(text);
     if (text.trim()) {
       setIsAppTranslationModalOpen(true);
@@ -334,6 +349,8 @@ function App() {
               onFileUpload={handleFileUpload}
               onTextSelection={handleTextSelection}
               translationConfig={translationConfig}
+              chatMode={isChatMode}
+              onToggleChatMode={() => setIsChatMode(!isChatMode)}
               onFullscreenChange={handleFullscreenChange}
               onPageTextExtracted={handlePageTextExtracted}
               onFileClose={handleCloseFile}
@@ -346,6 +363,7 @@ function App() {
       <FloatingActionButton
         onSettingsClick={() => setShowConfigModal(true)}
         onDocumentManagerClick={() => setShowDocumentManager(true)}
+        onChatClick={() => { setShowChatModal(true); setChatSelectedText(''); }}
       />
 
       {/* Document Manager Modal */}
@@ -389,7 +407,15 @@ function App() {
           portalContainer={fullscreenContainer || document.body}
           saving={appModalSaving}
           success={appModalSuccessMessage}
-          error={appModalError}
+        error={appModalError}
+      />
+      )}
+
+      {showChatModal && (
+        <ChatModal
+          isOpen={showChatModal}
+          onClose={() => setShowChatModal(false)}
+          selectedText={chatSelectedText}
         />
       )}
     </div>

--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -1,0 +1,85 @@
+.chat-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+}
+
+.chat-modal {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+  width: 90vw;
+  max-width: 600px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #eee;
+  background: #fcfcfc;
+  flex-shrink: 0;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.chat-message {
+  margin-bottom: 12px;
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+
+.chat-message.user {
+  text-align: right;
+}
+
+.chat-message.assistant {
+  text-align: left;
+}
+
+.chat-controls {
+  border-top: 1px solid #eee;
+  background: #fcfcfc;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.chat-selectors {
+  display: flex;
+  gap: 8px;
+}
+
+.chat-input {
+  width: 100%;
+  resize: vertical;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.chat-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { X, RotateCcw } from 'lucide-react';
+import aiCompletionService, { AIProvider, AIModel } from '../services/aiCompletionService';
+import apiKeyService from '../services/apiKeyService';
+import './ChatModal.css';
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedText: string;
+}
+
+const OPENAI_MODELS: { label: string; value: AIModel }[] = [
+  { label: 'gpt-4.1', value: 'gpt-4.1' },
+  { label: 'gpt-4.1-mini', value: 'gpt-4.1-mini' },
+  { label: 'gpt-4o', value: 'gpt-4o' },
+  { label: 'gpt-4o-mini', value: 'gpt-4o-mini' },
+];
+
+const OPENROUTER_MODELS: { label: string; value: AIModel }[] = [
+  { label: 'Gemma 3 27B IT (free)', value: 'google/gemma-3-27b-it:free' },
+  { label: 'Gemini 2.0 Flash Exp (free)', value: 'google/gemini-2.0-flash-exp:free' },
+  { label: 'Llama 4 Maverick (free)', value: 'meta-llama/llama-4-maverick:free' },
+  { label: 'Llama 4 Scout (free)', value: 'meta-llama/llama-4-scout:free' },
+  { label: 'DeepSeek Chat v3 (free)', value: 'deepseek/deepseek-chat-v3-0324:free' },
+  { label: 'Qwen 3 32B (free)', value: 'qwen/qwen3-32b:free' },
+  { label: 'Mistral Small 3.1 (free)', value: 'mistralai/mistral-small-3.1-24b-instruct:free' },
+];
+
+const GEMINI_MODELS: { label: string; value: AIModel }[] = [
+  { label: 'Gemini 2.0 Pro', value: 'gemini-2.0-pro' },
+  { label: 'Gemini 2.0 Flash', value: 'gemini-2.0-flash' },
+];
+
+const DEEPSEEK_MODELS: { label: string; value: AIModel }[] = [
+  { label: 'DeepSeek Chat', value: 'deepseek-chat' },
+  { label: 'DeepSeek Reasoner', value: 'deepseek-reasoner' },
+];
+
+function getModelOptions(provider: AIProvider) {
+  switch (provider) {
+    case 'openai':
+      return OPENAI_MODELS;
+    case 'openrouter':
+      return OPENROUTER_MODELS;
+    case 'gemini':
+      return GEMINI_MODELS;
+    case 'deepseek':
+      return DEEPSEEK_MODELS;
+    default:
+      return [];
+  }
+}
+
+function getDefaultModel(provider: AIProvider): AIModel {
+  switch (provider) {
+    case 'openai':
+      return 'gpt-4o-mini';
+    case 'openrouter':
+      return 'google/gemma-3-27b-it:free';
+    case 'gemini':
+      return 'gemini-2.0-flash';
+    case 'deepseek':
+      return 'deepseek-chat';
+    default:
+      return '' as AIModel;
+  }
+}
+
+const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, selectedText }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [provider, setProvider] = useState<AIProvider>('openai');
+  const [model, setModel] = useState<AIModel>('gpt-4o-mini');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (selectedText) {
+        setInput(`[${selectedText}] `);
+      }
+      textareaRef.current?.focus();
+    }
+  }, [isOpen, selectedText]);
+
+  const sendMessage = async () => {
+    const content = input.trim();
+    if (!content) return;
+    const userMsg: ChatMessage = { role: 'user', content };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput('');
+    try {
+      const apiKey = await apiKeyService.getApiKey(provider);
+      const context = newMessages.slice(-3).map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`).join('\n');
+      const reply = await aiCompletionService.completeText(context, { provider, model, apiKey });
+      setMessages([...newMessages, { role: 'assistant', content: reply }]);
+    } catch (err: any) {
+      setMessages([...newMessages, { role: 'assistant', content: `Error: ${err.message || 'Failed to fetch'}` }]);
+    }
+  };
+
+  const resetConversation = () => {
+    setMessages([]);
+    setInput('');
+  };
+
+  if (!isOpen) return null;
+
+  const modelOptions = getModelOptions(provider);
+
+  return createPortal(
+    <div className="chat-modal-overlay" onClick={onClose}>
+      <div className="chat-modal" onClick={e => e.stopPropagation()}>
+        <div className="chat-modal-header">
+          <h3>Chat</h3>
+          <button className="close-button" onClick={onClose} aria-label="Close chat">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="chat-messages">
+          {messages.map((m, idx) => (
+            <div key={idx} className={`chat-message ${m.role}`}>{m.content}</div>
+          ))}
+        </div>
+        <div className="chat-controls">
+          <div className="chat-selectors">
+            <select value={provider} onChange={e => {
+              const p = e.target.value as AIProvider;
+              setProvider(p);
+              setModel(getDefaultModel(p));
+            }}>
+              <option value="openai">OpenAI</option>
+              <option value="openrouter">OpenRouter</option>
+              <option value="gemini">Gemini</option>
+              <option value="deepseek">DeepSeek</option>
+            </select>
+            <select value={model} onChange={e => setModel(e.target.value as AIModel)}>
+              {modelOptions.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+          <textarea
+            ref={textareaRef}
+            className="chat-input"
+            rows={3}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder="Type your message..."
+          />
+          <div className="chat-actions">
+            <button className="btn btn-tertiary" onClick={resetConversation} title="Reset conversation">
+              <RotateCcw size={16} />
+            </button>
+            <button className="btn btn-primary" onClick={sendMessage}>Send</button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ChatModal;

--- a/src/components/FloatingActionButton.css
+++ b/src/components/FloatingActionButton.css
@@ -123,9 +123,21 @@
   background: #f57c00;
 }
 
+.fab-action-chat {
+  background: #2196f3;
+}
+
+.fab-action-chat:hover {
+  background: #1976d2;
+}
+
 /* Animation delays for staggered appearance */
 .fab-container.expanded .fab-action-documents {
   animation: fabActionSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.1s both;
+}
+
+.fab-container.expanded .fab-action-chat {
+  animation: fabActionSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.12s both;
 }
 
 .fab-container.expanded .fab-action-settings {

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
-import { Settings, FileText, Plus, X } from 'lucide-react';
+import { Settings, FileText, Plus, X, MessageCircle } from 'lucide-react';
 import './FloatingActionButton.css';
 
 interface FloatingActionButtonProps {
   onSettingsClick: () => void;
   onDocumentManagerClick: () => void;
+  onChatClick: () => void;
 }
 
 const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
   onSettingsClick,
   onDocumentManagerClick,
+  onChatClick
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -41,6 +43,15 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
           title="Document Manager"
         >
           <FileText size={20} />
+        </button>
+
+        <button
+          className="fab-action-btn fab-action-chat"
+          onClick={() => handleActionClick(onChatClick)}
+          aria-label="Chat"
+          title="Chat"
+        >
+          <MessageCircle size={20} />
         </button>
         
         <button

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -520,6 +520,14 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                     </button>
                   )}
                   <button
+                    className={`btn btn-compact btn-same-size ${chatMode ? 'btn-active' : ''}`}
+                    style={{ minWidth: 32, minHeight: 32 }}
+                    onClick={onToggleChatMode}
+                    title={chatMode ? 'Disable chat mode' : 'Enable chat mode'}
+                  >
+                    <MessageCircle size={14} />
+                  </button>
+                  <button
                     className={`btn btn-compact btn-same-size ${bookmarkedPage === pageNumber ? 'btn-active' : ''}`}
                     style={{ minWidth: 32, minHeight: 32 }}
                     onClick={handleBookmarkPage}


### PR DESCRIPTION
## Summary
- add ChatModal component with provider and model options
- extend FloatingActionButton to open chat
- include chat mode controls inside PDFViewer
- manage chat mode state in App

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461adfbfa4832e94eba3a94bd16e83