### PR TITLE
Enhance chat modal with markdown context

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ import tempfile
 import re
 import unicodedata
 from translation import translation_service
+from markitdown import MarkItDown
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -54,6 +55,9 @@ os.makedirs(WORKSPACE_PATH, exist_ok=True)
 
 # Allowed file extensions for documents
 ALLOWED_EXTENSIONS = {'pdf', 'doc', 'docx', 'txt', 'png', 'jpg', 'jpeg', 'gif'}
+
+# Cache for markdown conversions
+markdown_cache = {}
 
 def allowed_file(filename):
     return '.' in filename and \
@@ -569,6 +573,26 @@ def download_file(filename):
     
     except Exception as e:
         logger.error(f"Error downloading file {filename}: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+@app.route("/files/<filename>/markdown", methods=["GET"])
+def get_file_markdown(filename):
+    """Convert a stored file to Markdown using MarkItDown"""
+    try:
+        filename = safe_filename(filename)
+        if filename in markdown_cache:
+            return jsonify({"markdown": markdown_cache[filename]})
+
+        filepath = os.path.join(WORKSPACE_PATH, filename)
+        if not os.path.exists(filepath):
+            return jsonify({"error": "File not found"}), 404
+
+        with open(filepath, "rb") as f:
+            md = MarkItDown().convert_stream(f)
+        markdown_cache[filename] = md
+        return jsonify({"markdown": md})
+    except Exception as e:
+        logger.error(f"Error converting {filename} to markdown: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
 @app.route("/files/<filename>", methods=["DELETE"])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask
 flask-cors
 notion-client
 requests
+markitdown[all]

--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0,0,0,0.4);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -14,7 +14,7 @@
 .chat-modal {
   background: white;
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
   width: 90vw;
   max-width: 600px;
   max-height: 85vh;
@@ -37,20 +37,29 @@
   flex: 1;
   padding: 16px;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .chat-message {
-  margin-bottom: 12px;
+  max-width: 85%;
+  padding: 8px 12px;
+  border-radius: 8px;
   white-space: pre-wrap;
   line-height: 1.4;
 }
 
 .chat-message.user {
-  text-align: right;
+  align-self: flex-end;
+  background: #daf1fc;
+  border-bottom-right-radius: 0;
 }
 
 .chat-message.assistant {
-  text-align: left;
+  align-self: flex-start;
+  background: #f1f0f0;
+  border-bottom-left-radius: 0;
 }
 
 .chat-controls {

--- a/src/services/markdownService.ts
+++ b/src/services/markdownService.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+
+class MarkdownService {
+  private cache = new Map<string, string>();
+
+  async getMarkdown(fileName: string): Promise<string> {
+    if (this.cache.has(fileName)) {
+      return this.cache.get(fileName)!;
+    }
+    const encoded = encodeURIComponent(fileName);
+    const response = await axios.get(`/api/files/${encoded}/markdown`);
+    const md = response.data.markdown as string;
+    this.cache.set(fileName, md);
+    return md;
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+export default new MarkdownService();


### PR DESCRIPTION
## Summary
- add MarkItDown to backend requirements
- expose `/files/<filename>/markdown` endpoint
- implement MarkdownService on frontend
- use document markdown for chat prompts and improve chat bubbles
- include document name when launching ChatModal

## Testing
- `npm test --silent --prefix . -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684692558be4832eaa58b4f02d65f3c3