### PR TITLE
Enable streaming responses in chat modal

### DIFF
--- a/src/services/aiCompletionService.ts
+++ b/src/services/aiCompletionService.ts
@@ -27,6 +27,12 @@ export interface AICompletionOptions {
   maxTokens?: number;
 }
 
+export interface StreamingAICompletionOptions extends AICompletionOptions {
+  onProgress?: (partialText: string) => void;
+  onComplete?: (fullText: string) => void;
+  onError?: (error: Error) => void;
+}
+
 export async function completeText(
   prompt: string,
   options: AICompletionOptions
@@ -42,6 +48,30 @@ export async function completeText(
       return completeWithDeepSeek(prompt, options);
     default:
       throw new Error('Unsupported provider');
+  }
+}
+
+export async function completeTextStreaming(
+  prompt: string,
+  options: StreamingAICompletionOptions,
+): Promise<void> {
+  switch (options.provider) {
+    case 'openai':
+      return completeWithOpenAIStreaming(prompt, options);
+    case 'openrouter':
+      return completeWithOpenRouterStreaming(prompt, options);
+    case 'gemini':
+      return completeWithGeminiStreaming(prompt, options);
+    case 'deepseek':
+      return completeWithDeepSeekStreaming(prompt, options);
+    default:
+      try {
+        const result = await completeText(prompt, options);
+        options.onProgress?.(result);
+        options.onComplete?.(result);
+      } catch (error) {
+        options.onError?.(error as Error);
+      }
   }
 }
 
@@ -199,8 +229,314 @@ async function completeWithDeepSeek(
   throw new Error('No completion result from DeepSeek');
 }
 
+async function completeWithOpenAIStreaming(
+  prompt: string,
+  options: StreamingAICompletionOptions,
+): Promise<void> {
+  const { model, apiKey, temperature = 0.7, maxTokens = 1024, onProgress, onComplete, onError } = options;
+  const url = 'https://api.openai.com/v1/chat/completions';
+
+  const body = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: maxTokens,
+    temperature,
+    stream: true,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Failed to get response reader');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              fullText += content;
+              onProgress?.(fullText);
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to parse streaming response:', err);
+        }
+      }
+    }
+
+    onComplete?.(fullText);
+  } catch (error) {
+    onError?.(error as Error);
+  }
+}
+
+async function completeWithOpenRouterStreaming(
+  prompt: string,
+  options: StreamingAICompletionOptions,
+): Promise<void> {
+  const { model, apiKey, temperature = 0.7, maxTokens = 1024, onProgress, onComplete, onError } = options;
+  const url = 'https://openrouter.ai/api/v1/chat/completions';
+
+  const body = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: maxTokens,
+    temperature,
+    stream: true,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Failed to get response reader');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              fullText += content;
+              onProgress?.(fullText);
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to parse streaming response:', err);
+        }
+      }
+    }
+
+    onComplete?.(fullText);
+  } catch (error) {
+    onError?.(error as Error);
+  }
+}
+
+async function completeWithGeminiStreaming(
+  prompt: string,
+  options: StreamingAICompletionOptions,
+): Promise<void> {
+  const { model, apiKey, temperature = 0.7, maxTokens = 1024, onProgress, onComplete, onError } = options;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
+
+  const body = {
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: prompt }],
+      },
+    ],
+    generationConfig: {
+      temperature,
+      maxOutputTokens: maxTokens,
+    },
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Failed to get response reader');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (
+            parsed.candidates &&
+            parsed.candidates[0] &&
+            parsed.candidates[0].content &&
+            parsed.candidates[0].content.parts &&
+            parsed.candidates[0].content.parts[0] &&
+            parsed.candidates[0].content.parts[0].text
+          ) {
+            const content = parsed.candidates[0].content.parts[0].text;
+            if (content) {
+              fullText += content;
+              onProgress?.(fullText);
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to parse Gemini streaming response:', err);
+        }
+      }
+    }
+
+    onComplete?.(fullText);
+  } catch (error) {
+    onError?.(error as Error);
+  }
+}
+
+async function completeWithDeepSeekStreaming(
+  prompt: string,
+  options: StreamingAICompletionOptions,
+): Promise<void> {
+  const { model, apiKey: apiKeyFromOptions, temperature = 0.7, maxTokens = 1024, onProgress, onComplete, onError } = options;
+  const apiKey = apiKeyFromOptions || await apiKeyService.getApiKey('deepseek');
+  const baseUrl = 'https://api.deepseek.com/v1';
+  const url = `${baseUrl}/chat/completions`;
+
+  const body = {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: maxTokens,
+    temperature,
+    stream: true,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Failed to get response reader');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              fullText += content;
+              onProgress?.(fullText);
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to parse streaming response:', err);
+        }
+      }
+    }
+
+    onComplete?.(fullText);
+  } catch (error) {
+    onError?.(error as Error);
+  }
+}
+
 const aiCompletionService = {
   completeText,
+  completeTextStreaming,
 };
 
 export default aiCompletionService;


### PR DESCRIPTION
## Summary
- support streaming completions for all AI providers
- use streaming completions in `ChatModal`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684694914f58832ea0da0cdb85349785