### PR TITLE
Fix chat streaming display

### DIFF
--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -37,6 +37,7 @@
   flex: 1;
   padding: 16px;
   overflow-y: auto;
+  scroll-behavior: smooth;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -104,6 +104,7 @@ const ChatModal: React.FC<ChatModalProps> = ({
   const [isMarkdownLoading, setIsMarkdownLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -128,6 +129,11 @@ const ChatModal: React.FC<ChatModalProps> = ({
       }
     }
   }, [isOpen, selectedText, fileName]);
+
+  // Automatically scroll to the newest message when messages update
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isStreaming]);
 
   const sendMessage = async () => {
     const content = input.trim();
@@ -226,6 +232,7 @@ const ChatModal: React.FC<ChatModalProps> = ({
               {m.content}
             </div>
           ))}
+          <div ref={messagesEndRef} />
         </div>
         <div className="chat-controls">
           <div className="chat-selectors">


### PR DESCRIPTION
## Summary
- keep chat view scrolled to latest reply during streaming
- smooth-scroll chat messages container

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469e2fdbec832e8aadf01804385c4f