### PR TITLE
Add chat modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -430,6 +430,17 @@
   box-shadow: 0 3px 7px rgba(108, 117, 125, 0.25);
 }
 
+.btn-chat {
+  background-color: #9c27b0;
+  color: white;
+}
+
+.btn-chat:hover:not(:disabled) {
+  background-color: #7b1fa2;
+  transform: translateY(-1px);
+  box-shadow: 0 3px 7px rgba(156, 39, 176, 0.25);
+}
+
 .btn-active {
   background-color: #ffc107 !important; /* Keep warning color for active state */
   color: #212529 !important;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ConfigModal from './components/ConfigModal';
 import FloatingActionButton from './components/FloatingActionButton';
 import DocumentManagerModal from './components/DocumentManagerModal';
 import TranslationModal from './components/TranslationModal'; // Import TranslationModal
+import ChatModal from './components/ChatModal';
 import { NotionConfig, TranslationConfig, SavedDatabaseId } from './types';
 import configService from './services/configService';
 import notionService from './services/notionService';
@@ -47,6 +48,9 @@ function App() {
   const [appModalSaving, setAppModalSaving] = useState<boolean>(false);
   const [appModalSuccessMessage, setAppModalSuccessMessage] = useState<string>('');
   const [appModalError, setAppModalError] = useState<string>('');
+
+  const [showChatModal, setShowChatModal] = useState<boolean>(false);
+  const [chatInitialMessage, setChatInitialMessage] = useState<string | undefined>(undefined);
 
   // Load configuration from server on component mount
   useEffect(() => {
@@ -346,6 +350,10 @@ function App() {
       <FloatingActionButton
         onSettingsClick={() => setShowConfigModal(true)}
         onDocumentManagerClick={() => setShowDocumentManager(true)}
+        onChatClick={() => {
+          setChatInitialMessage(undefined);
+          setShowChatModal(true);
+        }}
       />
 
       {/* Document Manager Modal */}
@@ -370,6 +378,10 @@ function App() {
         savedDatabaseIds={savedDatabaseIds}
         onDatabaseIdSave={handleDatabaseIdSave}
         refreshDatabaseIds={refreshDatabaseIds}
+        onSendToChat={(text) => {
+          setChatInitialMessage(text);
+          setShowChatModal(true);
+        }}
       />
 
       {/* App-level Translation Modal */}
@@ -390,6 +402,18 @@ function App() {
           saving={appModalSaving}
           success={appModalSuccessMessage}
           error={appModalError}
+          onSendToChat={(text) => {
+            setChatInitialMessage(text);
+            setShowChatModal(true);
+          }}
+        />
+      )}
+
+      {showChatModal && (
+        <ChatModal
+          isOpen={showChatModal}
+          onClose={() => setShowChatModal(false)}
+          initialMessage={chatInitialMessage}
         />
       )}
     </div>
@@ -397,3 +421,4 @@ function App() {
 }
 
 export default App;
+

--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -1,0 +1,96 @@
+.chat-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10001;
+}
+
+.chat-modal {
+  background: #fff;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border-bottom: 1px solid #ddd;
+}
+
+.close-button {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.chat-config {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid #eee;
+}
+
+.chat-config select {
+  flex: 1;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-bubble {
+  padding: 8px 12px;
+  border-radius: 12px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+
+.chat-bubble.user {
+  background: #e0f7fa;
+  align-self: flex-end;
+}
+
+.chat-bubble.ai {
+  background: #ffe0f0;
+  align-self: flex-start;
+}
+
+.chat-input-section {
+  padding: 8px 12px;
+  border-top: 1px solid #eee;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-input-section textarea {
+  width: 100%;
+  resize: vertical;
+}
+
+.chat-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import ReactMarkdown from 'react-markdown';
+import chatService, { ChatMessage } from '../services/chatService';
+import apiKeyService from '../services/apiKeyService';
+import { TranslationProvider, TranslationModel } from '../types';
+import './ChatModal.css';
+
+interface ChatModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialMessage?: string;
+}
+
+const PROVIDER_OPTIONS: { label: string; value: TranslationProvider }[] = [
+  { label: 'OpenAI', value: 'openai' },
+  { label: 'OpenRouter', value: 'openrouter' },
+  { label: 'Google Gemini', value: 'gemini' },
+  { label: 'DeepSeek', value: 'deepseek' },
+];
+
+const OPENAI_MODELS: { label: string; value: TranslationModel }[] = [
+  { label: 'gpt-4.1', value: 'gpt-4.1' },
+  { label: 'gpt-4.1-mini', value: 'gpt-4.1-mini' },
+  { label: 'gpt-4o', value: 'gpt-4o' },
+  { label: 'gpt-4o-mini', value: 'gpt-4o-mini' },
+];
+const OPENROUTER_MODELS: { label: string; value: TranslationModel }[] = [
+  { label: 'Gemma 3 27B IT (free)', value: 'google/gemma-3-27b-it:free' },
+  { label: 'Gemini 2.0 Flash Exp (free)', value: 'google/gemini-2.0-flash-exp:free' },
+  { label: 'Llama 4 Maverick (free)', value: 'meta-llama/llama-4-maverick:free' },
+  { label: 'Llama 4 Scout (free)', value: 'meta-llama/llama-4-scout:free' },
+  { label: 'DeepSeek Chat v3 (free)', value: 'deepseek/deepseek-chat-v3-0324:free' },
+  { label: 'Qwen 3 32B (free)', value: 'qwen/qwen3-32b:free' },
+  { label: 'Mistral Small 3.1 (free)', value: 'mistralai/mistral-small-3.1-24b-instruct:free' },
+];
+const GEMINI_MODELS: { label: string; value: TranslationModel }[] = [
+  { label: 'Gemini 2.0 Pro', value: 'gemini-2.0-pro' },
+  { label: 'Gemini 2.0 Flash', value: 'gemini-2.0-flash' },
+];
+const DEEPSEEK_MODELS: { label: string; value: TranslationModel }[] = [
+  { label: 'DeepSeek Chat', value: 'deepseek-chat' },
+  { label: 'DeepSeek Reasoner', value: 'deepseek-reasoner' },
+];
+
+const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage }) => {
+  const [provider, setProvider] = useState<TranslationProvider>('openai');
+  const [model, setModel] = useState<TranslationModel>('gpt-4o-mini');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingText, setStreamingText] = useState('');
+  const [initialSent, setInitialSent] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen && modalRef.current) modalRef.current.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && initialMessage && !initialSent) {
+      setInitialSent(true);
+      setInputText(initialMessage);
+      sendMessage(initialMessage);
+    }
+    if (!isOpen) {
+      setInitialSent(false);
+    }
+  }, [isOpen, initialMessage]);
+
+  const getModelOptions = () => {
+    switch (provider) {
+      case 'openai':
+        return OPENAI_MODELS;
+      case 'openrouter':
+        return OPENROUTER_MODELS;
+      case 'gemini':
+        return GEMINI_MODELS;
+      case 'deepseek':
+        return DEEPSEEK_MODELS;
+      default:
+        return [];
+    }
+  };
+
+  const handleProviderChange = (prov: TranslationProvider) => {
+    let defaultModel: TranslationModel = '';
+    if (prov === 'openai') defaultModel = 'gpt-4o-mini';
+    if (prov === 'openrouter') defaultModel = 'google/gemma-3-27b-it:free';
+    if (prov === 'gemini') defaultModel = 'gemini-2.0-flash';
+    if (prov === 'deepseek') defaultModel = 'deepseek-chat';
+    setProvider(prov);
+    setModel(defaultModel);
+  };
+
+  const sendMessage = async (textOverride?: string) => {
+    const toSend = textOverride ?? inputText;
+    if (!toSend.trim()) return;
+    try {
+      const apiKey = await apiKeyService.getApiKey(provider);
+      const newMessages = [...messages, { role: 'user', content: toSend.trim() }];
+      setMessages(newMessages);
+      setInputText('');
+      setIsStreaming(true);
+      setStreamingText('');
+      await chatService.streamChat(newMessages, {
+        provider,
+        model,
+        apiKey,
+        onProgress: (txt) => setStreamingText(txt),
+        onComplete: (full) => {
+          setIsStreaming(false);
+          setStreamingText('');
+          setMessages([...newMessages, { role: 'assistant', content: full }]);
+        },
+        onError: () => {
+          setIsStreaming(false);
+          setStreamingText('');
+        },
+      });
+    } catch (err) {
+      console.error('Chat error:', err);
+      setIsStreaming(false);
+      setStreamingText('');
+    }
+  };
+
+  const resetConversation = () => {
+    setMessages([]);
+    setStreamingText('');
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className="chat-modal-overlay" onClick={onClose}>
+      <div className="chat-modal" onClick={(e) => e.stopPropagation()} ref={modalRef} tabIndex={-1}>
+        <div className="chat-header">
+          <h3>Chat</h3>
+          <button className="close-button" onClick={onClose} aria-label="Close">×</button>
+        </div>
+        <div className="chat-config">
+          <select value={provider} onChange={(e) => handleProviderChange(e.target.value as TranslationProvider)}>
+            {PROVIDER_OPTIONS.map(p => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+          <select value={model} onChange={(e) => setModel(e.target.value as TranslationModel)}>
+            {getModelOptions().map(m => (
+              <option key={m.value} value={m.value}>{m.label}</option>
+            ))}
+          </select>
+        </div>
+        <div className="chat-messages">
+          {messages.map((m, idx) => (
+            <div key={idx} className={`chat-bubble ${m.role === 'user' ? 'user' : 'ai'}`}>
+              <ReactMarkdown>{m.content}</ReactMarkdown>
+            </div>
+          ))}
+          {isStreaming && (
+            <div className="chat-bubble ai">
+              <ReactMarkdown>{streamingText}</ReactMarkdown>
+            </div>
+          )}
+        </div>
+        <div className="chat-input-section">
+          <textarea value={inputText} onChange={(e) => setInputText(e.target.value)} rows={2} />
+          <div className="chat-actions">
+            <button onClick={sendMessage} disabled={isStreaming || !inputText.trim()}>Send</button>
+            <button onClick={resetConversation} disabled={isStreaming}>Reset</button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ChatModal;
+

--- a/src/components/ConfigModal.tsx
+++ b/src/components/ConfigModal.tsx
@@ -20,6 +20,7 @@ interface ConfigModalProps {
   savedDatabaseIds?: SavedDatabaseId[];
   onDatabaseIdSave?: (databaseId: SavedDatabaseId) => void;
   refreshDatabaseIds?: () => void;
+  onSendToChat?: (text: string) => void;
 }
 
 type TabType = 'configuration' | 'database-ids' | 'tag-config' | 'backup';
@@ -36,7 +37,8 @@ const ConfigModal: React.FC<ConfigModalProps> = ({
   fullscreenContainer,
   savedDatabaseIds,
   onDatabaseIdSave,
-  refreshDatabaseIds
+  refreshDatabaseIds,
+  onSendToChat
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>('configuration');
   const [showHelpModal, setShowHelpModal] = useState(false);
@@ -62,10 +64,11 @@ const ConfigModal: React.FC<ConfigModalProps> = ({
             setTranslationConfig={setTranslationConfig}
             onClearSelection={onClearSelection}
             fullscreenContainer={fullscreenContainer}
-            savedDatabaseIds={savedDatabaseIds}
-            refreshDatabaseIds={refreshDatabaseIds}
-            isConfigModalOpen={isOpen}
-          />
+          savedDatabaseIds={savedDatabaseIds}
+          refreshDatabaseIds={refreshDatabaseIds}
+          isConfigModalOpen={isOpen}
+          onSendToChat={onSendToChat}
+        />
         );
       case 'database-ids':
         return (

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -20,6 +20,7 @@ interface ConfigPanelProps {
   savedDatabaseIds?: SavedDatabaseId[];
   refreshDatabaseIds?: () => void;
   isConfigModalOpen?: boolean; // New prop to indicate if config modal is open
+  onSendToChat?: (text: string) => void;
 }
 
 // Translation options constants
@@ -62,9 +63,10 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
   setTranslationConfig, 
   onClearSelection, 
   fullscreenContainer, 
-  savedDatabaseIds, 
+  savedDatabaseIds,
   refreshDatabaseIds,
-  isConfigModalOpen = false // Default to false for backward compatibility
+  isConfigModalOpen = false, // Default to false for backward compatibility
+  onSendToChat
 }) => {
   const [properties, setProperties] = useState<NotionProperty[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -927,6 +929,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
           portalContainer={document.body} // Ensures modal is portalled to the body
           success={success}
           saving={saving}
+          onSendToChat={onSendToChat}
         />
 
         <TranslationModal
@@ -946,6 +949,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({
           portalContainer={fullscreenContainer}
           success={success}
           saving={saving}
+          onSendToChat={onSendToChat}
         />
       </div>
     </div>

--- a/src/components/FloatingActionButton.css
+++ b/src/components/FloatingActionButton.css
@@ -111,6 +111,14 @@
   background: #4caf50;
 }
 
+.fab-action-chat {
+  background: #9c27b0;
+}
+
+.fab-action-chat:hover {
+  background: #7b1fa2;
+}
+
 .fab-action-settings:hover {
   background: #388e3c;
 }
@@ -128,8 +136,12 @@
   animation: fabActionSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.1s both;
 }
 
-.fab-container.expanded .fab-action-settings {
+.fab-container.expanded .fab-action-chat {
   animation: fabActionSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.15s both;
+}
+
+.fab-container.expanded .fab-action-settings {
+  animation: fabActionSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1) 0.2s both;
 }
 
 @keyframes fabActionSlideIn {

--- a/src/components/FloatingActionButton.tsx
+++ b/src/components/FloatingActionButton.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
-import { Settings, FileText, Plus, X } from 'lucide-react';
+import { Settings, FileText, MessageCircle, Plus, X } from 'lucide-react';
 import './FloatingActionButton.css';
 
 interface FloatingActionButtonProps {
   onSettingsClick: () => void;
   onDocumentManagerClick: () => void;
+  onChatClick: () => void;
 }
 
 const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
   onSettingsClick,
   onDocumentManagerClick,
+  onChatClick,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -41,6 +43,15 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({
           title="Document Manager"
         >
           <FileText size={20} />
+        </button>
+
+        <button
+          className="fab-action-btn fab-action-chat"
+          onClick={() => handleActionClick(onChatClick)}
+          aria-label="Chat"
+          title="Chat"
+        >
+          <MessageCircle size={20} />
         </button>
         
         <button

--- a/src/components/TranslationModal.tsx
+++ b/src/components/TranslationModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
+import { MessageCircle } from 'lucide-react';
 import { TranslationConfig } from '../types';
 import SuccessMessage from './SuccessMessage';
 
@@ -22,6 +23,7 @@ interface TranslationModalProps {
   success?: string;
   saving?: boolean;
   error?: string;
+  onSendToChat?: (text: string) => void;
 }
 
 const TranslationModal: React.FC<TranslationModalProps> = ({
@@ -41,7 +43,8 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
   portalContainer = null,
   success = '',
   saving = false,
-  error = ''
+  error = '',
+  onSendToChat
 }) => {
   const [selectedText, setSelectedText] = useState<string>('');
   const [modalAnnotation, setModalAnnotation] = useState<string>(annotation);
@@ -119,6 +122,13 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
       setModalAnnotation('');
       setModalPageNumber('');
       // NO limpiar selectedText aquí
+    }
+  };
+
+  const handleSendToChat = () => {
+    const text = selectedText.trim() || originalText.trim();
+    if (onSendToChat && text) {
+      onSendToChat(`[${text}]`);
     }
   };
 
@@ -387,14 +397,20 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
           >
             {saving ? 'Saving...' : 'Add Everything'}
           </button>
-          <button 
+          <button
             className="btn btn-secondary"
             onClick={handleAddSelection}
             disabled={!selectedText.trim() || isStreaming || saving}
           >
             {saving ? 'Saving...' : 'Add Selection'}
           </button>
-          <button 
+          {onSendToChat && (
+            <button className="btn btn-chat" onClick={handleSendToChat} disabled={isStreaming || saving}>
+              <MessageCircle size={16} />
+              <span style={{ marginLeft: '4px' }}>Send to chat</span>
+            </button>
+          )}
+          <button
             className="btn btn-tertiary"
             onClick={handleClose}
           >

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,0 +1,259 @@
+import apiKeyService from './apiKeyService';
+import { TranslationProvider, TranslationModel } from '../types';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export interface StreamingChatOptions {
+  provider: TranslationProvider;
+  model: TranslationModel;
+  apiKey: string;
+  onProgress?: (partial: string) => void;
+  onComplete?: (full: string) => void;
+  onError?: (err: Error) => void;
+}
+
+async function chatWithOpenAIStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
+  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const url = 'https://api.openai.com/v1/chat/completions';
+  const body = {
+    model,
+    messages,
+    max_tokens: 2048,
+    temperature: 0.2,
+    stream: true,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Failed to get response reader');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let full = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              full += content;
+              onProgress?.(full);
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to parse streaming response:', e);
+        }
+      }
+    }
+    onComplete?.(full);
+  } catch (err) {
+    onError?.(err as Error);
+  }
+}
+
+async function chatWithOpenRouterStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
+  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const url = 'https://openrouter.ai/api/v1/chat/completions';
+  const body = {
+    model,
+    messages,
+    max_tokens: 2048,
+    temperature: 0.2,
+    stream: true,
+  };
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Failed to get response reader');
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let full = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              full += content;
+              onProgress?.(full);
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to parse streaming response:', e);
+        }
+      }
+    }
+    onComplete?.(full);
+  } catch (err) {
+    onError?.(err as Error);
+  }
+}
+
+async function chatWithGeminiStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
+  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
+  const contents = messages.map(m => ({ role: m.role === 'assistant' ? 'model' : m.role, parts: [{ text: m.content }] }));
+  const body = {
+    contents,
+    generationConfig: { temperature: 0.2, maxOutputTokens: 2048 },
+  };
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Failed to get response reader');
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let full = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.candidates && parsed.candidates[0] && parsed.candidates[0].content && parsed.candidates[0].content.parts && parsed.candidates[0].content.parts[0] && parsed.candidates[0].content.parts[0].text) {
+            const content = parsed.candidates[0].content.parts[0].text;
+            if (content) {
+              full += content;
+              onProgress?.(full);
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to parse Gemini streaming response:', e);
+        }
+      }
+    }
+    onComplete?.(full);
+  } catch (err) {
+    onError?.(err as Error);
+  }
+}
+
+async function chatWithDeepSeekStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
+  const { model, apiKey: apiKeyFromOptions, onProgress, onComplete, onError } = options;
+  const apiKey = apiKeyFromOptions || await apiKeyService.getApiKey('deepseek');
+  const url = 'https://api.deepseek.com/v1/chat/completions';
+  const body = {
+    model,
+    messages,
+    max_tokens: 2048,
+    temperature: 0.2,
+    stream: true,
+  };
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Failed to get response reader');
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let full = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]' || !trimmed.startsWith('data: ')) continue;
+        try {
+          const jsonData = trimmed.slice(6);
+          const parsed = JSON.parse(jsonData);
+          if (parsed.choices && parsed.choices[0] && parsed.choices[0].delta) {
+            const content = parsed.choices[0].delta.content;
+            if (content) {
+              full += content;
+              onProgress?.(full);
+            }
+          }
+        } catch (e) {
+          console.warn('Failed to parse streaming response:', e);
+        }
+      }
+    }
+    onComplete?.(full);
+  } catch (err) {
+    onError?.(err as Error);
+  }
+}
+
+export async function streamChat(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
+  switch (options.provider) {
+    case 'openai':
+      return chatWithOpenAIStreaming(messages, options);
+    case 'openrouter':
+      return chatWithOpenRouterStreaming(messages, options);
+    case 'gemini':
+      return chatWithGeminiStreaming(messages, options);
+    case 'deepseek':
+      return chatWithDeepSeekStreaming(messages, options);
+    default:
+      throw new Error('Unsupported provider');
+  }
+}
+
+const chatService = { streamChat };
+export default chatService;


### PR DESCRIPTION
## Summary
- add send to chat button on selection modals and auto-stream selected text
- style chat button
- allow ChatModal to receive an initial message
- pipe send-to-chat events through ConfigModal and App

## Testing
- `npm test --silent` *(fails: `bash: npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846a43fd364832ebf462dfae0bae07d