### PR TITLE
Enable MarkItDown context

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask
 flask-cors
 notion-client
 requests
+markitdown[pdf]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -414,6 +414,7 @@ function App() {
           isOpen={showChatModal}
           onClose={() => setShowChatModal(false)}
           initialMessage={chatInitialMessage}
+          currentFile={pdfFile}
         />
       )}
     </div>

--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -94,3 +94,11 @@
   justify-content: flex-end;
 }
 
+.context-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  color: #666;
+}
+

--- a/src/services/markdownService.ts
+++ b/src/services/markdownService.ts
@@ -1,0 +1,16 @@
+class MarkdownService {
+  private baseUrl = '/api';
+
+  async getMarkdown(filename: string): Promise<string> {
+    const url = `${this.baseUrl}/files/${encodeURIComponent(filename)}/markdown`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to fetch markdown');
+    }
+    const data = await response.json();
+    return data.markdown as string;
+  }
+}
+
+export const markdownService = new MarkdownService();


### PR DESCRIPTION
## Summary
- support PDF→Markdown generation in backend with MarkItDown
- add endpoint to fetch (and lazily generate) Markdown
- provide frontend service for Markdown retrieval
- load PDF context when opening chat modal
- show spinner while context loads and send as system message

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846abe4389c832e9e1f7ded1a2fe45b