### PR TITLE
Improve ChatModal styling

### DIFF
--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -4,22 +4,27 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0,0,0,0.3);
+  background-color: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 10001;
+  backdrop-filter: blur(3px);
+  padding: 15px;
+  box-sizing: border-box;
 }
 
 .chat-modal {
   background: #fff;
-  border-radius: 8px;
-  width: 90%;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  width: 90vw;
   max-width: 600px;
-  max-height: 90vh;
+  max-height: 85vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  animation: modalFadeIn 0.25s ease-out;
 }
 
 .chat-header {
@@ -45,7 +50,7 @@
   border-bottom: 1px solid #eee;
 }
 
-.chat-config select {
+.chat-config .config-select {
   flex: 1;
 }
 
@@ -83,7 +88,7 @@
   gap: 8px;
 }
 
-.chat-input-section textarea {
+.chat-input-section .config-textarea {
   width: 100%;
   resize: vertical;
 }

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -168,12 +168,20 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
           <button className="close-button" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="chat-config">
-          <select value={provider} onChange={(e) => handleProviderChange(e.target.value as TranslationProvider)}>
+          <select
+            className="config-select"
+            value={provider}
+            onChange={(e) => handleProviderChange(e.target.value as TranslationProvider)}
+          >
             {PROVIDER_OPTIONS.map(p => (
               <option key={p.value} value={p.value}>{p.label}</option>
             ))}
           </select>
-          <select value={model} onChange={(e) => setModel(e.target.value as TranslationModel)}>
+          <select
+            className="config-select"
+            value={model}
+            onChange={(e) => setModel(e.target.value as TranslationModel)}
+          >
             {getModelOptions().map(m => (
               <option key={m.value} value={m.value}>{m.label}</option>
             ))}
@@ -197,10 +205,27 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
           )}
         </div>
         <div className="chat-input-section">
-          <textarea value={inputText} onChange={(e) => setInputText(e.target.value)} rows={2} />
+          <textarea
+            className="config-textarea"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            rows={2}
+          />
           <div className="chat-actions">
-            <button onClick={sendMessage} disabled={isStreaming || isContextLoading || !inputText.trim()}>Send</button>
-            <button onClick={resetConversation} disabled={isStreaming}>Reset</button>
+            <button
+              className="btn btn-primary"
+              onClick={sendMessage}
+              disabled={isStreaming || isContextLoading || !inputText.trim()}
+            >
+              Send
+            </button>
+            <button
+              className="btn btn-tertiary"
+              onClick={resetConversation}
+              disabled={isStreaming}
+            >
+              Reset
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- style ChatModal dropdowns, buttons and text area like the rest of the app
- match modal overlay with application styles

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bee31e54832e826056cda895a7c4