### PR TITLE
Add token limit option in chat modal

### DIFF
--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -43,10 +43,16 @@
   gap: 8px;
   padding: 8px 12px;
   border-bottom: 1px solid #eee;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .chat-config select {
   flex: 1;
+}
+
+.token-input {
+  width: 80px;
 }
 
 .chat-messages {

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -56,6 +56,8 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
   const [initialSent, setInitialSent] = useState(false);
   const [markdownContext, setMarkdownContext] = useState('');
   const [isContextLoading, setIsContextLoading] = useState(false);
+  const [limitTokens, setLimitTokens] = useState(false);
+  const [tokenLimit, setTokenLimit] = useState('2048');
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -135,6 +137,7 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
         provider,
         model,
         apiKey,
+        maxTokens: limitTokens ? parseInt(tokenLimit, 10) || undefined : undefined,
         onProgress: (txt) => setStreamingText(txt),
         onComplete: (full) => {
           setIsStreaming(false);
@@ -178,6 +181,24 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
               <option key={m.value} value={m.value}>{m.label}</option>
             ))}
           </select>
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              checked={limitTokens}
+              onChange={e => setLimitTokens(e.target.checked)}
+              className="checkbox-input"
+            />
+            <span className="checkbox-text">Limitar tokens</span>
+          </label>
+          {limitTokens && (
+            <input
+              type="number"
+              className="token-input"
+              value={tokenLimit}
+              min="1"
+              onChange={e => setTokenLimit(e.target.value)}
+            />
+          )}
         </div>
         <div className="chat-messages">
           {isContextLoading && (

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -10,18 +10,19 @@ export interface StreamingChatOptions {
   provider: TranslationProvider;
   model: TranslationModel;
   apiKey: string;
+  maxTokens?: number;
   onProgress?: (partial: string) => void;
   onComplete?: (full: string) => void;
   onError?: (err: Error) => void;
 }
 
 async function chatWithOpenAIStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
   const url = 'https://api.openai.com/v1/chat/completions';
   const body = {
     model,
     messages,
-    max_tokens: 2048,
+    max_tokens: maxTokens ?? 2048,
     temperature: 0.2,
     stream: true,
   };
@@ -80,12 +81,12 @@ async function chatWithOpenAIStreaming(messages: ChatMessage[], options: Streami
 }
 
 async function chatWithOpenRouterStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
   const url = 'https://openrouter.ai/api/v1/chat/completions';
   const body = {
     model,
     messages,
-    max_tokens: 2048,
+    max_tokens: maxTokens ?? 2048,
     temperature: 0.2,
     stream: true,
   };
@@ -135,12 +136,12 @@ async function chatWithOpenRouterStreaming(messages: ChatMessage[], options: Str
 }
 
 async function chatWithGeminiStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey, onProgress, onComplete, onError } = options;
+  const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
   const contents = messages.map(m => ({ role: m.role === 'assistant' ? 'model' : m.role, parts: [{ text: m.content }] }));
   const body = {
     contents,
-    generationConfig: { temperature: 0.2, maxOutputTokens: 2048 },
+    generationConfig: { temperature: 0.2, maxOutputTokens: maxTokens ?? 2048 },
   };
   try {
     const response = await fetch(url, {
@@ -185,13 +186,13 @@ async function chatWithGeminiStreaming(messages: ChatMessage[], options: Streami
 }
 
 async function chatWithDeepSeekStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey: apiKeyFromOptions, onProgress, onComplete, onError } = options;
+  const { model, apiKey: apiKeyFromOptions, maxTokens, onProgress, onComplete, onError } = options;
   const apiKey = apiKeyFromOptions || await apiKeyService.getApiKey('deepseek');
   const url = 'https://api.deepseek.com/v1/chat/completions';
   const body = {
     model,
     messages,
-    max_tokens: 2048,
+    max_tokens: maxTokens ?? 2048,
     temperature: 0.2,
     stream: true,
   };


### PR DESCRIPTION
## Summary
- add max token limit checkbox and input in ChatModal
- wire token limit to chat service
- support optional max tokens in chatService

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bef75224832e815a77fd0d66edda