### PR TITLE
Add checkmark indicator for loaded markdown

### DIFF
--- a/src/components/ChatModal.css
+++ b/src/components/ChatModal.css
@@ -113,3 +113,15 @@
   color: #666;
 }
 
+.context-loaded {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+}
+
+.checkmark {
+  color: #28a745;
+  font-size: 18px;
+}
+

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -214,6 +214,11 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
               <LoadingSpinner size={16} /> Cargando contexto...
             </div>
           )}
+          {!isContextLoading && markdownContext && (
+            <div className="context-loaded" aria-label="Markdown loaded">
+              <span className="checkmark">&#10003;</span>
+            </div>
+          )}
           {messages.map((m, idx) => (
             <div key={idx} className={`chat-bubble ${m.role === 'user' ? 'user' : 'ai'}`}>
               <ReactMarkdown>{m.content}</ReactMarkdown>


### PR DESCRIPTION
## Summary
- add green checkmark when markdown context is loaded in ChatModal
- style the checkmark indicator

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c159177c832e9ea2b5d29ffd3c00