### PR TITLE
Cache markdown context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ NotyPDF helps you extract and save text from PDF documents to your Notion databa
 - **Configuration Menu**: Comprehensive settings panel with tabbed interface for easy navigation.
 - **Backup & Restore**: Export and import your configurations to ensure your settings are never lost.
 - **Translation Support**: Optional AI-powered translation with multiple provider support.
+- **AI Chat Context**: When chatting with an AI, NotyPDF sends the markdown text
+  content as formatted text, never the markdown file itself, and fingerprints it
+  so providers can cache the context and avoid wasting tokens.
+- **Provider Support**: Caching via `system_fingerprint` is documented for
+  OpenAI and OpenRouter only. DeepSeek and Gemini do not mention similar
+  functionality.
 - **Easy Configuration**: User-friendly interface for setting up Notion API credentials and database columns.
 
 ## How It Works

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -57,11 +57,34 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
   const [isContextLoading, setIsContextLoading] = useState(false);
   const [limitTokens, setLimitTokens] = useState(false);
   const [tokenLimit, setTokenLimit] = useState('2048');
+  const [contextFingerprint, setContextFingerprint] = useState<string>();
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen && modalRef.current) modalRef.current.focus();
   }, [isOpen]);
+
+  // Compute a stable fingerprint for the markdown context so providers can cache it
+  useEffect(() => {
+    async function computeFingerprint(text: string): Promise<string> {
+      const data = new TextEncoder().encode(text);
+      const hash = await crypto.subtle.digest('SHA-256', data);
+      return Array.from(new Uint8Array(hash))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    if (markdownContext) {
+      computeFingerprint(markdownContext)
+        .then(setContextFingerprint)
+        .catch(err => {
+          console.error('Fingerprint error:', err);
+          setContextFingerprint(undefined);
+        });
+    } else {
+      setContextFingerprint(undefined);
+    }
+  }, [markdownContext]);
 
   useEffect(() => {
     const loadContext = async () => {
@@ -124,14 +147,20 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
       setInputText('');
       setIsStreaming(true);
       setStreamingText('');
-      const messagesToSend = messages.length === 0 && markdownContext
-        ? [{ role: 'system', content: markdownContext }, ...userMessages]
-        : userMessages;
+      // If a markdown context is available, send its *text* to the AI as a
+      // system message. We never transmit the markdown file itself. A stable
+      // fingerprint is sent alongside so OpenAI/OpenRouter can cache the
+      // context. Other providers ignore this optional value.
+      const messagesToSend =
+        messages.length === 0 && markdownContext
+          ? [{ role: 'system', content: markdownContext }, ...userMessages]
+          : userMessages;
       await chatService.streamChat(messagesToSend, {
         provider,
         model,
         apiKey,
         maxTokens: limitTokens ? parseInt(tokenLimit, 10) || undefined : undefined,
+        systemFingerprint: contextFingerprint,
         onProgress: (txt) => setStreamingText(txt),
         onComplete: (full) => {
           setIsStreaming(false);

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -11,21 +11,23 @@ export interface StreamingChatOptions {
   model: TranslationModel;
   apiKey: string;
   maxTokens?: number;
+  systemFingerprint?: string;
   onProgress?: (partial: string) => void;
   onComplete?: (full: string) => void;
   onError?: (err: Error) => void;
 }
 
 async function chatWithOpenAIStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
+  const { model, apiKey, maxTokens, onProgress, onComplete, onError, systemFingerprint } = options;
   const url = 'https://api.openai.com/v1/chat/completions';
-  const body = {
+  const body: Record<string, any> = {
     model,
     messages,
     max_tokens: maxTokens ?? 2048,
     temperature: 0.2,
     stream: true,
   };
+  if (systemFingerprint) body.system_fingerprint = systemFingerprint;
 
   try {
     const response = await fetch(url, {
@@ -81,15 +83,16 @@ async function chatWithOpenAIStreaming(messages: ChatMessage[], options: Streami
 }
 
 async function chatWithOpenRouterStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
-  const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
+  const { model, apiKey, maxTokens, onProgress, onComplete, onError, systemFingerprint } = options;
   const url = 'https://openrouter.ai/api/v1/chat/completions';
-  const body = {
+  const body: Record<string, any> = {
     model,
     messages,
     max_tokens: maxTokens ?? 2048,
     temperature: 0.2,
     stream: true,
   };
+  if (systemFingerprint) body.system_fingerprint = systemFingerprint;
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -137,6 +140,8 @@ async function chatWithOpenRouterStreaming(messages: ChatMessage[], options: Str
 
 async function chatWithGeminiStreaming(messages: ChatMessage[], options: StreamingChatOptions): Promise<void> {
   const { model, apiKey, maxTokens, onProgress, onComplete, onError } = options;
+  // Gemini's API docs don't mention a system fingerprint parameter,
+  // so caching the context this way is currently unsupported.
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?key=${apiKey}&alt=sse`;
   const contents = messages.map(m => ({ role: m.role === 'assistant' ? 'model' : m.role, parts: [{ text: m.content }] }));
   const body = {
@@ -196,6 +201,8 @@ async function chatWithDeepSeekStreaming(messages: ChatMessage[], options: Strea
     temperature: 0.2,
     stream: true,
   };
+  // DeepSeek's API documentation doesn't list a "system_fingerprint" parameter.
+  // Caching the markdown context in this way is therefore not available.
   try {
     const response = await fetch(url, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- fingerprint markdown context so the provider can cache it
- pass the fingerprint in chat requests
- note that Gemini and DeepSeek have no fingerprint support
- explain caching in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9ea6708832eac55cf5e3138cfa2