### PR TITLE
Cache markdown context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ NotyPDF helps you extract and save text from PDF documents to your Notion databa
 - **Configuration Menu**: Comprehensive settings panel with tabbed interface for easy navigation.
 - **Backup & Restore**: Export and import your configurations to ensure your settings are never lost.
 - **Translation Support**: Optional AI-powered translation with multiple provider support.
+- **AI Chat Context**: When chatting with an AI, NotyPDF sends the markdown text
+  content as formatted text, never the markdown file itself, and fingerprints it
+  so OpenAI or OpenRouter can cache the context and avoid wasting tokens.
+- **Provider Support**: OpenAI and OpenRouter rely on the `system_fingerprint`
+  parameter for caching. DeepSeek performs automatic prefix caching on its
+  servers without needing a fingerprint, while Gemini provides no caching
+  mechanism.
 - **Easy Configuration**: User-friendly interface for setting up Notion API credentials and database columns.
 
 ## How It Works

--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -57,11 +57,34 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
   const [isContextLoading, setIsContextLoading] = useState(false);
   const [limitTokens, setLimitTokens] = useState(false);
   const [tokenLimit, setTokenLimit] = useState('2048');
+  const [contextFingerprint, setContextFingerprint] = useState<string>();
   const modalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (isOpen && modalRef.current) modalRef.current.focus();
   }, [isOpen]);
+
+  // Compute a stable fingerprint for the markdown context so providers can cache it
+  useEffect(() => {
+    async function computeFingerprint(text: string): Promise<string> {
+      const data = new TextEncoder().encode(text);
+      const hash = await crypto.subtle.digest('SHA-256', data);
+      return Array.from(new Uint8Array(hash))
+        .map(b => b.toString(16).padStart(2, '0'))
+        .join('');
+    }
+
+    if (markdownContext) {
+      computeFingerprint(markdownContext)
+        .then(setContextFingerprint)
+        .catch(err => {
+          console.error('Fingerprint error:', err);
+          setContextFingerprint(undefined);
+        });
+    } else {
+      setContextFingerprint(undefined);
+    }
+  }, [markdownContext]);
 
   useEffect(() => {
     const loadContext = async () => {
@@ -124,14 +147,21 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
       setInputText('');
       setIsStreaming(true);
       setStreamingText('');
-      const messagesToSend = messages.length === 0 && markdownContext
-        ? [{ role: 'system', content: markdownContext }, ...userMessages]
-        : userMessages;
+      // If a markdown context is available, send its *text* to the AI as a
+      // system message. We never transmit the markdown file itself. A stable
+      // fingerprint accompanies the request so OpenAI/OpenRouter can cache the
+      // context. DeepSeek caches prefixes automatically, and Gemini simply
+      // ignores this value.
+      const messagesToSend =
+        messages.length === 0 && markdownContext
+          ? [{ role: 'system', content: markdownContext }, ...userMessages]
+          : userMessages;
       await chatService.streamChat(messagesToSend, {
         provider,
         model,
         apiKey,
         maxTokens: limitTokens ? parseInt(tokenLimit, 10) || undefined : undefined,
+        systemFingerprint: contextFingerprint,
         onProgress: (txt) => setStreamingText(txt),
         onComplete: (full) => {
           setIsStreaming(false);


### PR DESCRIPTION
## Summary
- fingerprint markdown context so the provider can cache it
- pass the fingerprint in chat requests
- note that Gemini and DeepSeek have no fingerprint support
- explain caching in README
- clarify that DeepSeek handles caching automatically

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9ea6708832eac55cf5e3138cfa2