### PR TITLE
Fix markdown context injection

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -119,14 +119,19 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
     if (!toSend.trim() || isContextLoading) return;
     try {
       const apiKey = await apiKeyService.getApiKey(provider);
-      const userMessages = [...messages, { role: 'user', content: toSend.trim() }];
+      const userMessage: ChatMessage = { role: 'user', content: toSend.trim() };
+      const userMessages = [...messages, userMessage];
       setMessages(userMessages);
       setInputText('');
       setIsStreaming(true);
       setStreamingText('');
-      const messagesToSend = messages.length === 0 && markdownContext
-        ? [{ role: 'system', content: markdownContext }, ...userMessages]
-        : userMessages;
+      let messagesToSend: ChatMessage[];
+      if (messages.length === 0 && markdownContext) {
+        const combined = `[DOCUMENTO]\n${markdownContext}\n[/DOCUMENTO]\n\n${toSend.trim()}`;
+        messagesToSend = [...messages, { role: 'user', content: combined }];
+      } else {
+        messagesToSend = [...messages, userMessage];
+      }
       await chatService.streamChat(messagesToSend, {
         provider,
         model,


### PR DESCRIPTION
## Summary
- combine markdown with the user's initial message so context is sent in the first request

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d0cb08f0832e8cafde3f73fca140