### PR TITLE
Reset conversation when changing chat model

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -112,6 +112,12 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
     if (prov === 'deepseek') defaultModel = 'deepseek-chat';
     setProvider(prov);
     setModel(defaultModel);
+    resetConversation();
+  };
+
+  const handleModelChange = (mod: TranslationModel) => {
+    setModel(mod);
+    resetConversation();
   };
 
   const sendMessage = async (textOverride?: string) => {
@@ -192,7 +198,7 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
           <select
             className="config-select"
             value={model}
-            onChange={(e) => setModel(e.target.value as TranslationModel)}
+            onChange={(e) => handleModelChange(e.target.value as TranslationModel)}
           >
             {getModelOptions().map(m => (
               <option key={m.value} value={m.value}>{m.label}</option>


### PR DESCRIPTION
## Summary
- reset chat history whenever the provider or model selection changes
- call reset logic in model dropdown

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d3d9152c832e9821725682181677