### PR TITLE
Add PDF bulk download

### DIFF
--- a/src/components/DocumentManagerModal.css
+++ b/src/components/DocumentManagerModal.css
@@ -174,6 +174,41 @@
   box-shadow: none;
 }
 
+/* Download All Button */
+.download-all-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #10b981;
+  color: white;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.download-all-button:hover:not(:disabled) {
+  background: #059669;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+.download-all-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(16, 185, 129, 0.3);
+}
+
+.download-all-button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
 .drop-area {
   display: inline-flex;
   align-items: center;

--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -263,6 +263,31 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
     setShowClearAllConfirm(false);
   };
 
+  const handleDownloadAllPdfs = async () => {
+    const pdfCount = documents.filter(d => d.name.toLowerCase().endsWith('.pdf')).length;
+    if (pdfCount === 0) {
+      alert('No PDF files to download.');
+      return;
+    }
+    try {
+      setIsLoading(true);
+      const blob = await fileService.downloadAllPdfsZip();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'all_pdfs.zip';
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Error downloading PDFs:', error);
+      alert('Failed to download PDFs. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const filteredDocuments = documents
     .filter(
       doc =>
@@ -335,6 +360,15 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
           >
             <Trash2 size={20} />
             <span>Clear All Files</span>
+          </button>
+          <button
+            className="download-all-button"
+            onClick={handleDownloadAllPdfs}
+            disabled={isLoading || documents.filter(d => d.name.toLowerCase().endsWith('.pdf')).length === 0}
+            title="Download all PDFs as ZIP"
+          >
+            <Download size={20} />
+            <span>Download All PDFs</span>
           </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -242,6 +242,31 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
     }
   };
 
+  const handleDownloadAllPdfs = async () => {
+    const pdfCount = documents.filter(d => d.name.toLowerCase().endsWith('.pdf')).length;
+    if (pdfCount === 0) {
+      alert('No PDF files to download.');
+      return;
+    }
+    try {
+      setIsLoading(true);
+      const blob = await fileService.downloadAllPdfsZip();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'all_pdfs.zip';
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Error downloading PDFs:', error);
+      alert('Failed to download PDFs. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const cancelClearAll = () => {
     setShowClearAllConfirm(false);
   };
@@ -301,6 +326,15 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           >
             <Trash2 size={20} />
             <span>Clear All Files</span>
+          </button>
+          <button
+            className="download-all-button"
+            onClick={handleDownloadAllPdfs}
+            disabled={isLoading || documents.filter(d => d.name.toLowerCase().endsWith('.pdf')).length === 0}
+            title="Download all PDFs as ZIP"
+          >
+            <Download size={20} />
+            <span>Download All PDFs</span>
           </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -175,6 +175,17 @@ class FileService {
   }
 
   /**
+   * Download all PDF files as a ZIP archive
+   */
+  async downloadAllPdfsZip(): Promise<Blob> {
+    const response = await fetch(`${this.baseUrl}/files/download/all`);
+    if (!response.ok) {
+      throw new Error(`Failed to download PDFs: ${response.status} ${response.statusText}`);
+    }
+    return await response.blob();
+  }
+
+  /**
    * Get the download URL for a file
    */
   getDownloadUrl(filename: string): string {


### PR DESCRIPTION
## Summary
- allow downloading all workspace PDFs as a zip
- add a helper in `fileService` to fetch the zip
- expose new button in Document Manager components
- style the new download-all button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846e4a5d214832e8e1c73261135acd9