### PR TITLE
Fix full PDF chat with OpenAI/OpenRouter

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -196,8 +196,17 @@ const ChatModal: React.FC<ChatModalProps> = ({ isOpen, onClose, initialMessage, 
           const combined = `[PAGE ${currentPage}]\n${markdownContext}\n[/PAGE]\n\n${toSend.trim()}`;
           messagesToSend = [...messages, { role: 'user', content: combined }];
         } else if (contextMode === 'full-pdf' && fileData) {
-          const combined = `[FILE:${currentFile?.name};base64]\n${fileData}\n[/FILE]\n\n${toSend.trim()}`;
-          messagesToSend = [...messages, { role: 'user', content: combined }];
+          if (provider === 'openai' || provider === 'openrouter') {
+            const dataUrl = `data:application/pdf;base64,${fileData}`;
+            const content = [
+              { type: 'text', text: toSend.trim() },
+              { type: 'file', file: { filename: currentFile?.name || 'document.pdf', file_data: dataUrl } },
+            ];
+            messagesToSend = [...messages, { role: 'user', content }];
+          } else {
+            const combined = `[FILE:${currentFile?.name};base64]\n${fileData}\n[/FILE]\n\n${toSend.trim()}`;
+            messagesToSend = [...messages, { role: 'user', content: combined }];
+          }
         } else {
           messagesToSend = [...messages, userMessage];
         }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,9 +1,18 @@
 import apiKeyService from './apiKeyService';
 import { TranslationProvider, TranslationModel } from '../types';
 
+export type ChatFile = {
+  filename: string;
+  file_data: string;
+};
+
+export type ChatContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'file'; file: ChatFile };
+
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
-  content: string;
+  content: string | ChatContentPart[];
 }
 
 export interface StreamingChatOptions {


### PR DESCRIPTION
## Summary
- allow ChatMessage to send file attachments
- send `full-pdf` messages as file content for OpenAI and OpenRouter

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847244b2100832ebdeef45ef1cc52ab