### PR TITLE
Improve single page switch speed

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -645,41 +645,37 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                   title="Select text to send to Notion"
                   style={{ userSelect: 'text' }}
                 >
-                  {isContinuousView ? (
-                    // Continuous view - show all pages
-                    Array.from(new Array(numPages), (el, index) => (
+                  {Array.from(new Array(numPages), (el, index) => (
+                    <div
+                      key={`page_${index + 1}`}
+                      ref={el => (pageRefs.current[index] = el)}
+                      style={{
+                        marginBottom: '20px',
+                        display:
+                          isContinuousView || pageNumber === index + 1
+                            ? 'block'
+                            : 'none'
+                      }}
+                    >
+                      <Page
+                        pageNumber={index + 1}
+                        renderTextLayer={true}
+                        renderAnnotationLayer={true}
+                        scale={scale}
+                        width={pdfWidth}
+                      />
                       <div
-                        key={`page_${index + 1}`}
-                        ref={el => (pageRefs.current[index] = el)}
-                        style={{ marginBottom: '20px' }}
+                        style={{
+                          textAlign: 'center',
+                          marginTop: '10px',
+                          fontSize: '12px',
+                          color: '#666'
+                        }}
                       >
-                        <Page
-                          pageNumber={index + 1}
-                          renderTextLayer={true}
-                          renderAnnotationLayer={true}
-                          scale={scale}
-                          width={pdfWidth}
-                        />
-                        <div style={{ 
-                          textAlign: 'center', 
-                          marginTop: '10px', 
-                          fontSize: '12px', 
-                          color: '#666' 
-                        }}>
-                          Page {index + 1}
-                        </div>
+                        Page {index + 1}
                       </div>
-                    ))
-                  ) : (
-                    // Single page view
-                    <Page
-                      pageNumber={pageNumber}
-                      renderTextLayer={true}
-                      renderAnnotationLayer={true}
-                      scale={scale}
-                      width={pdfWidth}
-                    />
-                  )}
+                    </div>
+                  ))}
                 </div>
               </Document>
             </div>


### PR DESCRIPTION
## Summary
- keep PDF pages mounted and toggle visibility instead of re-rendering them

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3afc9a8c832eaf40cdbe0d4ef941