### PR TITLE
Integrate Kokoro TTS

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -19,6 +19,13 @@ services:
     networks:
       - default
 
+  kokoro:
+    build: ./kokoro-server
+    ports:
+      - "40001:40001"
+    networks:
+      - default
+
 networks:
   default:
     name: pdf-reader-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,17 @@ services:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
       - NOTION_API_KEY=${NOTION_API_KEY}
     volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./data:/app/data
       - ./myworkspace:/myworkspace
     restart: unless-stopped
+    networks:
+      - default
+
+  kokoro:
+    build: ./kokoro-server
+    ports:
+      - "40001:40001"
     networks:
       - default
 

--- a/kokoro-server/Dockerfile
+++ b/kokoro-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y espeak-ng && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir fastapi uvicorn[standard] soundfile kokoro==0.9.4
+COPY server.py .
+EXPOSE 40001
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "40001"]

--- a/kokoro-server/server.py
+++ b/kokoro-server/server.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from fastapi.responses import StreamingResponse
+from kokoro import KPipeline
+import io
+import soundfile as sf
+
+# List of available voices from Kokoro
+VOICES = [
+    'af_alloy','af_aoede','af_bella','af_heart','af_jessica','af_kore','af_nicole','af_nova','af_river','af_sarah','af_sky',
+    'am_adam','am_echo','am_eric','am_fenrir','am_liam','am_michael','am_onyx','am_puck','am_santa',
+    'bf_alice','bf_emma','bf_isabella','bf_lily',
+    'bm_daniel','bm_fable','bm_george','bm_lewis',
+    'ef_dora','em_alex','em_santa',
+    'ff_siwis',
+    'hf_alpha','hf_beta','hm_omega','hm_psi',
+    'if_sara','im_nicola',
+    'jf_alpha','jf_gongitsune','jf_nezumi','jf_tebukuro','jm_kumo',
+    'pf_dora','pm_alex','pm_santa',
+    'zf_xiaobei','zf_xiaoni','zf_xiaoxiao','zf_xiaoyi',
+    'zm_yunjian','zm_yunxi','zm_yunxia','zm_yunyang'
+]
+
+LANG_CODES = sorted(set(v[0] for v in VOICES))
+PIPELINES = {c: KPipeline(lang_code=c) for c in LANG_CODES}
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'], allow_headers=['*'])
+
+class TTSRequest(BaseModel):
+    text: str
+    voice: str
+    speed: float = 1.0
+
+@app.get('/voices')
+def list_voices():
+    return {'voices': VOICES}
+
+@app.post('/speak')
+async def speak(req: TTSRequest):
+    if req.voice not in VOICES:
+        return {'error': 'voice not available'}
+    pipeline = PIPELINES[req.voice[0]]
+    pack = pipeline.load_voice(req.voice)
+    audio_data = None
+    for _, _, audio in pipeline(req.text, voice=req.voice, speed=req.speed):
+        if audio is not None:
+            audio_data = audio.numpy()
+            break
+    if audio_data is None:
+        return {'error': 'no audio'}
+    buf = io.BytesIO()
+    sf.write(buf, audio_data, 24000, format='wav')
+    buf.seek(0)
+    return StreamingResponse(buf, media_type='audio/wav')

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,14 @@ server {
         proxy_send_timeout 600s;
     }
 
+    location /tts/ {
+        proxy_pass http://kokoro:40001/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
-import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, BookCopy, Layout, Languages, Bookmark, X } from 'lucide-react';
+import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, BookCopy, Layout, Languages, Bookmark, X, Volume2 } from 'lucide-react';
+import { listVoices, speak } from '../services/ttsService';
 import DocumentManagerPanel from './DocumentManagerPanel';
 import { TranslationConfig } from '../types';
 import configService from '../services/configService';
@@ -32,12 +33,19 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
   const [isDoublePageView, setIsDoublePageView] = useState<boolean>(false);
   const [toolbarPosition, setToolbarPosition] = useState<'top' | 'bottom'>('top');
   const [isExtractingText, setIsExtractingText] = useState<boolean>(false);
+  const [isSpeaking, setIsSpeaking] = useState<boolean>(false);
+  const [voices, setVoices] = useState<string[]>([]);
+  const [selectedVoice, setSelectedVoice] = useState<string>('af_heart');
   const [skipPageInput, setSkipPageInput] = useState<string>("");
   const [bookmarkedPage, setBookmarkedPage] = useState<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pdfContainerRef = useRef<HTMLDivElement>(null);
   const pageRefs = useRef<(HTMLDivElement | null)[]>([]);
   const documentRef = useRef<any>(null);
+
+  useEffect(() => {
+    listVoices().then(setVoices).catch(err => console.error('Failed to load voices', err));
+  }, []);
 
   useEffect(() => {
     if (onPageChange) onPageChange(pageNumber);
@@ -275,6 +283,33 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
       setError('Failed to extract text from current page');
     } finally {
       setIsExtractingText(false);
+    }
+  }
+
+  async function getCurrentPageText(): Promise<string> {
+    if (!file) return '';
+    const loadingTask = pdfjs.getDocument(URL.createObjectURL(file));
+    const pdf = await loadingTask.promise;
+    const page = await pdf.getPage(pageNumber);
+    const textContent = await page.getTextContent();
+    return textContent.items.map((item: any) => item.str).join(' ').trim();
+  }
+
+  async function speakCurrentPage() {
+    if (isSpeaking) return;
+    try {
+      setIsSpeaking(true);
+      const text = await getCurrentPageText();
+      if (!text) return;
+      const blob = await speak(text, selectedVoice);
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.play();
+    } catch (err) {
+      console.error('Error speaking page:', err);
+      setError('Failed to generate speech');
+    } finally {
+      setIsSpeaking(false);
     }
   }
 
@@ -552,6 +587,27 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                       <Languages size={14} />
                     </button>
                   )}
+                  {voices.length > 0 && (
+                    <select
+                      value={selectedVoice}
+                      onChange={(e) => setSelectedVoice(e.target.value)}
+                      className="config-select"
+                      style={{ height: 28 }}
+                    >
+                      {voices.map(v => (
+                        <option key={v} value={v}>{v}</option>
+                      ))}
+                    </select>
+                  )}
+                  <button
+                    className={`btn btn-compact btn-same-size ${isSpeaking ? 'btn-loading' : ''}`}
+                    style={{ minWidth: 32, minHeight: 32 }}
+                    onClick={speakCurrentPage}
+                    disabled={isSpeaking || !file}
+                    title={isSpeaking ? 'Generating audio...' : 'Read page aloud'}
+                  >
+                    <Volume2 size={14} />
+                  </button>
                   <button
                     className={`btn btn-compact btn-same-size ${bookmarkedPage === pageNumber ? 'btn-active' : ''}`}
                     style={{ minWidth: 32, minHeight: 32 }}

--- a/src/services/ttsService.ts
+++ b/src/services/ttsService.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const API_BASE_URL = '/tts';
+
+export async function listVoices(): Promise<string[]> {
+  const res = await axios.get(`${API_BASE_URL}/voices`);
+  return res.data.voices || [];
+}
+
+export async function speak(text: string, voice: string, speed = 1): Promise<Blob> {
+  const res = await axios.post(`${API_BASE_URL}/speak`, { text, voice, speed }, { responseType: 'blob' });
+  return res.data as Blob;
+}


### PR DESCRIPTION
## Summary
- add Kokoro TTS service and Dockerfile
- wire the new service in docker compose
- expose /tts path in nginx config
- add frontend voice picker and read-aloud button
- implement API calls to TTS backend

## Testing
- `npm run build`
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d3f38de14832eb0a8a4183a390406