### PR TITLE
Fix page rendering on continuous view toggle

### DIFF
--- a/src/components/ChatModal.tsx
+++ b/src/components/ChatModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import { Send, RotateCcw } from 'lucide-react';
 import { pdfjs } from 'react-pdf';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.js';
 import chatService, { ChatMessage, ChatContentPart } from '../services/chatService';
 import apiKeyService from '../services/apiKeyService';
 import { markdownService } from '../services/markdownService';
@@ -10,7 +11,7 @@ import { TranslationProvider, TranslationModel } from '../types';
 import LoadingSpinner from './LoadingSpinner';
 import './ChatModal.css';
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
 interface ChatModalProps {
   isOpen: boolean;

--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.js';
 import { Upload, FileText, ChevronLeft, ChevronRight, ZoomIn, ZoomOut, RotateCcw, Lightbulb, Maximize, Minimize, BookOpen, FileIcon, Layout, Languages, Bookmark, X } from 'lucide-react';
 import DocumentManagerPanel from './DocumentManagerPanel';
 import { TranslationConfig } from '../types';
@@ -7,7 +8,7 @@ import configService from '../services/configService';
 import { translateTextStreaming } from '../services/translationService';
 import { fileService } from '../services/fileService';
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
 interface PDFViewerProps {
   file: File | null;
@@ -639,13 +640,16 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                   title="Select text to send to Notion"
                   style={{ userSelect: 'text' }}
                 >
-                  {isContinuousView ? (
-                    // Continuous view - show all pages
-                    Array.from(new Array(numPages), (el, index) => (
+                  {Array.from(new Array(numPages), (el, index) => {
+                    const isVisible = isContinuousView || pageNumber === index + 1;
+                    return (
                       <div
                         key={`page_${index + 1}`}
                         ref={el => (pageRefs.current[index] = el)}
-                        style={{ marginBottom: '20px' }}
+                        style={{
+                          marginBottom: isVisible ? '20px' : '0px',
+                          display: isVisible ? 'block' : 'none'
+                        }}
                       >
                         <Page
                           pageNumber={index + 1}
@@ -654,26 +658,21 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                           scale={scale}
                           width={pdfWidth}
                         />
-                        <div style={{ 
-                          textAlign: 'center', 
-                          marginTop: '10px', 
-                          fontSize: '12px', 
-                          color: '#666' 
-                        }}>
-                          Page {index + 1}
-                        </div>
+                        {isContinuousView && (
+                          <div
+                            style={{
+                              textAlign: 'center',
+                              marginTop: '10px',
+                              fontSize: '12px',
+                              color: '#666'
+                            }}
+                          >
+                            Page {index + 1}
+                          </div>
+                        )}
                       </div>
-                    ))
-                  ) : (
-                    // Single page view
-                    <Page
-                      pageNumber={pageNumber}
-                      renderTextLayer={true}
-                      renderAnnotationLayer={true}
-                      scale={scale}
-                      width={pdfWidth}
-                    />
-                  )}
+                    );
+                  })}
                 </div>
               </Document>
             </div>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,5 @@
+declare module 'pdfjs-dist/build/pdf.worker.min.js' {
+  const workerSrc: string;
+  export default workerSrc;
+}
+


### PR DESCRIPTION
## Summary
- keep PDF pages mounted and toggle visibility on view change
- bundle pdf.js worker locally so zoom works again

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d566801d4832ea0f90670266c16be