### PR TITLE
Optimize continuous/single view switch

### DIFF
--- a/src/components/PDFViewer.tsx
+++ b/src/components/PDFViewer.tsx
@@ -639,41 +639,37 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ file, onFileUpload, onTextSelecti
                   title="Select text to send to Notion"
                   style={{ userSelect: 'text' }}
                 >
-                  {isContinuousView ? (
-                    // Continuous view - show all pages
-                    Array.from(new Array(numPages), (el, index) => (
-                      <div
-                        key={`page_${index + 1}`}
-                        ref={el => (pageRefs.current[index] = el)}
-                        style={{ marginBottom: '20px' }}
-                      >
-                        <Page
-                          pageNumber={index + 1}
-                          renderTextLayer={true}
-                          renderAnnotationLayer={true}
-                          scale={scale}
-                          width={pdfWidth}
-                        />
-                        <div style={{ 
-                          textAlign: 'center', 
-                          marginTop: '10px', 
-                          fontSize: '12px', 
-                          color: '#666' 
-                        }}>
-                          Page {index + 1}
+                  {
+                    Array.from(new Array(numPages), (el, index) => {
+                      const isVisible = isContinuousView || pageNumber === index + 1;
+                      return (
+                        <div
+                          key={`page_${index + 1}`}
+                          ref={el => (pageRefs.current[index] = el)}
+                          style={{ marginBottom: '20px', display: isVisible ? 'block' : 'none' }}
+                        >
+                          <Page
+                            key={`page_${index + 1}_${scale}`}
+                            pageNumber={index + 1}
+                            renderTextLayer={true}
+                            renderAnnotationLayer={true}
+                            scale={scale}
+                            width={pdfWidth}
+                          />
+                          {isContinuousView && (
+                            <div style={{
+                              textAlign: 'center',
+                              marginTop: '10px',
+                              fontSize: '12px',
+                              color: '#666'
+                            }}>
+                              Page {index + 1}
+                            </div>
+                          )}
                         </div>
-                      </div>
-                    ))
-                  ) : (
-                    // Single page view
-                    <Page
-                      pageNumber={pageNumber}
-                      renderTextLayer={true}
-                      renderAnnotationLayer={true}
-                      scale={scale}
-                      width={pdfWidth}
-                    />
-                  )}
+                      );
+                    })
+                  }
                 </div>
               </Document>
             </div>


### PR DESCRIPTION
## Summary
- keep all pages mounted and toggle visibility instead of re-rendering
- force Page components to remount when zooming to prevent blank pages

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684db6085534832eb8093c2b453fa1e3