### PR TITLE
Implement folder creation for Document Manager

### DIFF
--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -128,6 +128,19 @@ class FileService {
     }
   }
 
+  async createFolder(folderName: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/files/create-folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ folderName })
+    });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to create folder');
+    }
+  }
+
   /**
    * Get list of archived files
    */


### PR DESCRIPTION
## Summary
- list folders in `/files` endpoint
- add `/files/create-folder` API to backend
- expose `createFolder` in `fileService`
- enable creating folders from Document Manager panels
- show folders with folder icons and disable irrelevant actions

## Testing
- `npm install`
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684ddde4eb28832ead1ae912da90e9d6