### PR TITLE
Add page navigation in translation modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import FloatingActionButton from './components/FloatingActionButton';
 import DocumentManagerModal from './components/DocumentManagerModal';
 import TranslationModal from './components/TranslationModal'; // Import TranslationModal
 import ChatModal from './components/ChatModal';
+import { pdfjs } from 'react-pdf';
+
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
 import { NotionConfig, TranslationConfig, SavedDatabaseId } from './types';
 import configService from './services/configService';
 import notionService from './services/notionService';
@@ -49,6 +52,10 @@ function App() {
   const [appModalSaving, setAppModalSaving] = useState<boolean>(false);
   const [appModalSuccessMessage, setAppModalSuccessMessage] = useState<string>('');
   const [appModalError, setAppModalError] = useState<string>('');
+
+  // Page navigation state for translation modal
+  const [translationModalPage, setTranslationModalPage] = useState<number>(1);
+  const [translationModalTotalPages, setTranslationModalTotalPages] = useState<number>(0);
 
   const [showChatModal, setShowChatModal] = useState<boolean>(false);
   const [chatInitialMessage, setChatInitialMessage] = useState<string | undefined>(undefined);
@@ -187,15 +194,51 @@ function App() {
     }
   }, [translationConfig]);
 
+  const getPageText = useCallback(async (page: number): Promise<string> => {
+    if (!pdfFile) return '';
+    const pdf = await pdfjs.getDocument(URL.createObjectURL(pdfFile)).promise;
+    const pg = await pdf.getPage(page);
+    const tc = await pg.getTextContent();
+    return tc.items.map((i: any) => i.str).join(' ').trim();
+  }, [pdfFile]);
+
   const handlePageTextExtracted = useCallback(async (text: string, pageNumber: number) => {
-    // For page text extraction, we can use the same logic as text selection
+    setTranslationModalPage(pageNumber);
+    if (pdfFile) {
+      try {
+        const pdf = await pdfjs.getDocument(URL.createObjectURL(pdfFile)).promise;
+        setTranslationModalTotalPages(pdf.numPages);
+      } catch (err) {
+        console.error('Error loading PDF:', err);
+      }
+    }
     await handleTextSelection(text);
-    // TODO: use pageNumber if needed for specific functionality
-  }, [handleTextSelection]);
+  }, [handleTextSelection, pdfFile]);
+
+  const changeTranslationModalPage = useCallback(async (page: number) => {
+    if (page < 1 || (translationModalTotalPages && page > translationModalTotalPages)) return;
+    const text = await getPageText(page);
+    setTranslationModalPage(page);
+    await handleTextSelection(text);
+  }, [getPageText, handleTextSelection, translationModalTotalPages]);
+
+  const handleNextTranslationPage = useCallback(() => {
+    if (translationModalPage < translationModalTotalPages) {
+      changeTranslationModalPage(translationModalPage + 1);
+    }
+  }, [translationModalPage, translationModalTotalPages, changeTranslationModalPage]);
+
+  const handlePrevTranslationPage = useCallback(() => {
+    if (translationModalPage > 1) {
+      changeTranslationModalPage(translationModalPage - 1);
+    }
+  }, [translationModalPage, changeTranslationModalPage]);
 
   const handleClearSelection = useCallback(() => {
     setSelectedText('');
     setIsAppTranslationModalOpen(false);
+    setTranslationModalPage(1);
+    setTranslationModalTotalPages(0);
   }, []);
 
   const handleConfigChange = useCallback((config: NotionConfig) => {
@@ -246,8 +289,10 @@ function App() {
     setAppModalSuccessMessage('');
     setAppModalIsStreaming(false);
     setAppModalStreamingText('');
+    setTranslationModalPage(1);
+    setTranslationModalTotalPages(0);
     // Optionally clear selectedText if it should not persist for ConfigModal
-    // setSelectedText(''); 
+    // setSelectedText('');
   };
 
   // App-level modal "Add to Notion" handlers with actual implementation
@@ -404,6 +449,10 @@ function App() {
           saving={appModalSaving}
           success={appModalSuccessMessage}
           error={appModalError}
+          currentPdfPage={translationModalPage}
+          totalPdfPages={translationModalTotalPages}
+          onNextPage={handleNextTranslationPage}
+          onPrevPage={handlePrevTranslationPage}
           onSendToChat={(text) => {
             setChatInitialMessage(text);
             setShowChatModal(true);

--- a/src/components/TranslationModal.tsx
+++ b/src/components/TranslationModal.tsx
@@ -24,6 +24,10 @@ interface TranslationModalProps {
   saving?: boolean;
   error?: string;
   onSendToChat?: (text: string) => void;
+  currentPdfPage?: number;
+  totalPdfPages?: number;
+  onNextPage?: () => void;
+  onPrevPage?: () => void;
 }
 
 const TranslationModal: React.FC<TranslationModalProps> = ({
@@ -44,7 +48,11 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
   success = '',
   saving = false,
   error = '',
-  onSendToChat
+  onSendToChat,
+  currentPdfPage,
+  totalPdfPages,
+  onNextPage,
+  onPrevPage
 }) => {
   const [selectedText, setSelectedText] = useState<string>('');
   const [modalAnnotation, setModalAnnotation] = useState<string>(annotation);
@@ -253,7 +261,18 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
               </p>
             </div>
           )}
-          <div 
+          {typeof currentPdfPage === 'number' && typeof totalPdfPages === 'number' && totalPdfPages > 0 && (
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+              <button className="btn btn-secondary" onClick={onPrevPage} disabled={currentPdfPage <= 1 || !onPrevPage}>
+                Previous Page
+              </button>
+              <span style={{ fontWeight: 500 }}>Page {currentPdfPage} / {totalPdfPages}</span>
+              <button className="btn btn-secondary" onClick={onNextPage} disabled={currentPdfPage >= totalPdfPages || !onNextPage}>
+                Next Page
+              </button>
+            </div>
+          )}
+          <div
             className="text-display"
             ref={textRef}
             onMouseUp={handleTextSelection}


### PR DESCRIPTION
## Summary
- enhance App translation modal with page navigation state and controls
- expose page navigation props in `TranslationModal`
- add next/previous page buttons and page indicator

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684e875aaf50832eacfa297b9d6f36e9