### PR TITLE
Add file moving capability

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -801,6 +801,40 @@ def unarchive_file(filename):
         logger.error(f"Error unarchiving file {filename}: {str(e)}")
         return jsonify({"error": str(e)}), 500
 
+
+@app.route("/files/move", methods=["POST"])
+def move_files():
+    """Move one or more files into the specified folder inside the workspace"""
+    try:
+        data = request.get_json() or {}
+        filenames = data.get("filenames", [])
+        destination = safe_filename(data.get("destination", ""))
+
+        dest_dir = os.path.join(WORKSPACE_PATH, destination) if destination else WORKSPACE_PATH
+
+        if destination and not os.path.isdir(dest_dir):
+            return jsonify({"error": "Destination folder not found"}), 404
+
+        moved = []
+        errors = []
+        for name in filenames:
+            fname = safe_filename(name)
+            src = os.path.join(WORKSPACE_PATH, fname)
+            if not os.path.exists(src):
+                errors.append({"file": fname, "error": "File not found"})
+                continue
+            dst = os.path.join(dest_dir, fname)
+            try:
+                os.rename(src, dst)
+                moved.append(fname)
+            except Exception as e:
+                errors.append({"file": fname, "error": str(e)})
+
+        return jsonify({"success": len(errors) == 0, "moved": moved, "errors": errors})
+    except Exception as e:
+        logger.error(f"Error moving files: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
 @app.route("/files/clear", methods=["DELETE"])
 def clear_all_files():
     """Delete all files from the workspace directory"""

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -24,6 +24,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
   const [showArchiveModal, setShowArchiveModal] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     loadDocuments();
@@ -259,6 +260,60 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
     }
   };
 
+  const toggleFileSelection = (name: string) => {
+    setSelectedFiles(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  };
+
+  const moveSelectedFiles = async (destination: string) => {
+    if (selectedFiles.size === 0) return;
+    try {
+      setIsLoading(true);
+      await fileService.moveFiles(Array.from(selectedFiles), destination);
+      await loadDocuments();
+      setSelectedFiles(new Set());
+    } catch (error) {
+      console.error('Error moving files:', error);
+      alert('Failed to move files.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDragStartFile = (event: React.DragEvent<HTMLDivElement>, name: string) => {
+    if (!selectedFiles.has(name)) {
+      setSelectedFiles(new Set([name]));
+    }
+    event.dataTransfer.setData('text/plain', Array.from(selectedFiles).join(','));
+  };
+
+  const handleFolderDrop = async (event: React.DragEvent<HTMLDivElement>, folder: string) => {
+    event.preventDefault();
+    const names = event.dataTransfer.getData('text/plain').split(',').filter(Boolean);
+    if (names.length === 0) return;
+    try {
+      setIsLoading(true);
+      await fileService.moveFiles(names, folder);
+      await loadDocuments();
+      setSelectedFiles(new Set());
+    } catch (error) {
+      console.error('Error moving files:', error);
+      alert('Failed to move files.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRootDrop = async (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const names = event.dataTransfer.getData('text/plain').split(',').filter(Boolean);
+    if (names.length === 0) return;
+    await moveSelectedFiles('');
+  };
+
   const confirmClearAll = async () => {
     try {
       setIsLoading(true);
@@ -391,6 +446,15 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
             <Archive size={20} />
             <span>Archived Documents</span>
           </button>
+          <button
+            className="upload-button"
+            onClick={() => moveSelectedFiles('')}
+            disabled={isLoading || selectedFiles.size === 0}
+            title="Move selected files to main folder"
+          >
+            <Folder size={20} />
+            <span>Move to Main</span>
+          </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}
             onDragOver={handleDragOver}
@@ -415,7 +479,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
               <p>Loading documents...</p>
             </div>
           ) : (
-            <div className="documents-list">
+            <div className="documents-list" onDragOver={(e) => e.preventDefault()} onDrop={handleRootDrop}>
               {filteredDocuments.length === 0 ? (
                 <div className="empty-state">
                   <FileText size={48} />
@@ -426,8 +490,17 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
                 filteredDocuments.map((doc) => (
                   <div
                     key={doc.name}
-                    className={`document-item ${currentFile?.name === doc.name ? 'current' : ''}`}
+                    className={`document-item ${currentFile?.name === doc.name ? 'current' : ''} ${selectedFiles.has(doc.name) ? 'selected' : ''}`}
+                    draggable={doc.type !== 'folder'}
+                    onDragStart={(e) => handleDragStartFile(e, doc.name)}
+                    onDragOver={doc.type === 'folder' ? (e) => e.preventDefault() : undefined}
+                    onDrop={doc.type === 'folder' ? (e) => handleFolderDrop(e, doc.name) : undefined}
                   >
+                    <input
+                      type="checkbox"
+                      checked={selectedFiles.has(doc.name)}
+                      onChange={() => toggleFileSelection(doc.name)}
+                    />
                     <div className="document-icon">
                       {doc.type === 'folder' ? <Folder size={20} /> : <FileText size={20} />}
                     </div>

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -261,6 +261,18 @@ class FileService {
     }
   }
 
+  async moveFiles(filenames: string[], destination: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/files/move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filenames, destination })
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to move files');
+    }
+  }
+
   /**
    * Delete all files from the server
    */


### PR DESCRIPTION
## Summary
- implement backend API to move files into folders
- support moving multiple files via `fileService.moveFiles`
- allow selecting and dragging files in Document Manager panel/modal
- add button to move selected files to the main folder

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e8d7399e8832e927514fd374e1ceb