### PR TITLE
Cambiar botones del gestor de documentos

### DIFF
--- a/src/components/DocumentManagerModal.css
+++ b/src/components/DocumentManagerModal.css
@@ -115,11 +115,12 @@
 .upload-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   background: #007acc;
   color: white;
-  padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 50%;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -143,11 +144,12 @@
 .clear-all-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   background: #ef4444;
   color: white;
-  padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 50%;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -178,11 +180,12 @@
 .download-all-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   background: #10b981;
   color: white;
-  padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 50%;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -213,11 +216,12 @@
 .archived-view-button {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   background: #6b7280;
   color: white;
-  padding: 12px 20px;
-  border-radius: 8px;
+  border-radius: 50%;
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -522,7 +526,8 @@
   }
 
   .upload-button {
-    padding: 10px 16px;
+    width: 36px;
+    height: 36px;
     font-size: 13px;
   }
 
@@ -588,7 +593,8 @@
   }
 
   .upload-button {
-    padding: 8px 14px;
+    width: 32px;
+    height: 32px;
     font-size: 12px;
   }
 

--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -440,27 +440,25 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
               disabled={isLoading}
               multiple
             />
-          <label htmlFor="file-upload" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
+          <label htmlFor="file-upload" className={`upload-button ${isLoading ? 'disabled' : ''}`}
+            title={isLoading ? uploadProgress || 'Upload Documents' : 'Upload Documents'}>
             <Upload size={20} />
-            <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
           </label>
           <button
             className="upload-button"
             onClick={handleCreateFolder}
             disabled={isLoading || isCreatingFolder}
-            title="Create new folder"
+            title={isCreatingFolder ? 'Creating...' : 'New Folder'}
           >
             <FolderPlus size={20} />
-            <span>{isCreatingFolder ? 'Creating...' : 'New Folder'}</span>
           </button>
           <button
             className="clear-all-button"
             onClick={handleClearAllFiles}
             disabled={isLoading || documents.length === 0}
-            title={documents.length === 0 ? "No files to clear" : `Clear all ${documents.length} files`}
+            title={documents.length === 0 ? 'No files to clear' : `Clear all ${documents.length} files`}
           >
             <Trash2 size={20} />
-            <span>Clear All Files</span>
           </button>
           <button
             className="download-all-button"
@@ -469,7 +467,6 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
             title="Download all PDFs as ZIP"
           >
             <Download size={20} />
-            <span>Download All PDFs</span>
           </button>
           <button
             className="archived-view-button"
@@ -478,7 +475,6 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
             title="View archived documents"
           >
             <Archive size={20} />
-            <span>Archived Documents</span>
           </button>
           <button
             className="upload-button"
@@ -487,7 +483,6 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
             title="Move selected files to main folder"
           >
             <Folder size={20} />
-            <span>Move to Main</span>
           </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -406,18 +406,17 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
               disabled={isLoading}
               multiple
             />
-          <label htmlFor="file-upload-inline" className={`upload-button ${isLoading ? 'disabled' : ''}`}>
+          <label htmlFor="file-upload-inline" className={`upload-button ${isLoading ? 'disabled' : ''}`}
+            title={isLoading ? uploadProgress || 'Upload Documents' : 'Upload Documents'}>
             <Upload size={20} />
-            <span>{isLoading ? (uploadProgress || 'Uploading...') : 'Upload Documents'}</span>
           </label>
           <button
             className="upload-button"
             onClick={handleCreateFolder}
             disabled={isLoading || isCreatingFolder}
-            title="Create new folder"
+            title={isCreatingFolder ? 'Creating...' : 'New Folder'}
           >
             <FolderPlus size={20} />
-            <span>{isCreatingFolder ? 'Creating...' : 'New Folder'}</span>
           </button>
           <button
             className="clear-all-button"
@@ -426,7 +425,6 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
             title={documents.length === 0 ? 'No files to clear' : `Clear all ${documents.length} files`}
           >
             <Trash2 size={20} />
-            <span>Clear All Files</span>
           </button>
           <button
             className="download-all-button"
@@ -435,7 +433,6 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
             title="Download all PDFs as ZIP"
           >
             <Download size={20} />
-            <span>Download All PDFs</span>
           </button>
           <button
             className="archived-view-button"
@@ -444,7 +441,6 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
             title="View archived documents"
           >
             <Archive size={20} />
-            <span>Archived Documents</span>
           </button>
           <button
             className="upload-button"
@@ -453,7 +449,6 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
             title="Move selected files to main folder"
           >
             <Folder size={20} />
-            <span>Move to Main</span>
           </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}


### PR DESCRIPTION
## Summary
- hacer redondos los botones del gestor de documentos
- dejar solo iconos en los botones

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684e92039b9c832e9742bcb3f77349b1