### PR TITLE
Add folder modal opening

### DIFF
--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -11,6 +11,8 @@ interface DocumentManagerModalProps {
   onClose: () => void;
   onFileUpload: (file: File) => void;
   currentFile?: File | null;
+  /** Path that should be opened when the modal is shown */
+  initialPath?: string;
 }
 
 const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
@@ -18,6 +20,7 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
   onClose,
   onFileUpload,
   currentFile,
+  initialPath = '',
 }) => {
   const [documents, setDocuments] = useState<FileInfo[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -36,7 +39,9 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
-  const [currentPath, setCurrentPath] = useState('');
+  const [currentPath, setCurrentPath] = useState(
+    initialPath ? (initialPath.endsWith('/') ? initialPath : `${initialPath}/`) : ''
+  );
 
   const enterFolder = (folderPath: string) => {
     setCurrentPath(folderPath.endsWith('/') ? folderPath : folderPath + '/');
@@ -54,6 +59,17 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
     setCurrentPath('');
     setSelectedFiles(new Set());
   };
+
+  // Reset path when modal opens or the initialPath prop changes
+  useEffect(() => {
+    if (isOpen) {
+      if (initialPath) {
+        setCurrentPath(initialPath.endsWith('/') ? initialPath : `${initialPath}/`);
+      } else {
+        setCurrentPath('');
+      }
+    }
+  }, [isOpen, initialPath]);
 
   // Load documents from server on component mount
   useEffect(() => {

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -5,6 +5,7 @@ import { fileService, FileInfo } from '../services/fileService';
 import ConfirmationModal from './ConfirmationModal';
 import DocumentArchiveModal from './DocumentArchiveModal';
 import CreateFolderModal from './CreateFolderModal';
+import DocumentManagerModal from './DocumentManagerModal';
 
 interface DocumentManagerPanelProps {
   onFileUpload: (file: File) => void;
@@ -25,6 +26,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
+  const [openFolderPath, setOpenFolderPath] = useState<string | null>(null);
 
   useEffect(() => {
     loadDocuments();
@@ -512,7 +514,17 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
                       </div>
                     </div>
                     <div className="document-actions">
-                      {doc.type !== 'folder' && (
+                      {doc.type === 'folder' ? (
+                        <button
+                          className="action-btn load-btn"
+                          onClick={() => setOpenFolderPath(doc.name)}
+                          aria-label="Open folder"
+                          title="Open folder"
+                          disabled={isLoading}
+                        >
+                          <Play size={16} />
+                        </button>
+                      ) : (
                         <>
                           <button
                             className="action-btn load-btn"
@@ -583,6 +595,13 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           onClose={() => setShowArchiveModal(false)}
           onFileUpload={onFileUpload}
           currentFile={currentFile}
+        />
+        <DocumentManagerModal
+          isOpen={openFolderPath !== null}
+          onClose={() => setOpenFolderPath(null)}
+          onFileUpload={onFileUpload}
+          currentFile={currentFile}
+          initialPath={openFolderPath || ''}
         />
         <CreateFolderModal
           isOpen={showFolderModal}


### PR DESCRIPTION
## Summary
- show button to open folders inside a modal
- support initialPath for `DocumentManagerModal`

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e96e0aefc832ebdc49df8e20383e8