### PR TITLE
Add modal to move files

### DIFF
--- a/src/components/DocumentManagerModal.css
+++ b/src/components/DocumentManagerModal.css
@@ -278,6 +278,66 @@
   box-shadow: none;
 }
 
+/* Move to Folder Button */
+.move-folder-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: #8b5cf6;
+  color: white;
+  border-radius: 50%;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+}
+
+.move-folder-button:hover:not(:disabled) {
+  background: #7c3aed;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.move-folder-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(139, 92, 246, 0.3);
+}
+
+.move-folder-button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Move Files Modal */
+.folder-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.folder-choice {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #f3f4f6;
+  cursor: pointer;
+}
+
+.folder-choice:hover {
+  background: #f3f4f6;
+}
+
 .drop-area {
   display: inline-flex;
   align-items: center;

--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -5,6 +5,7 @@ import { fileService, FileInfo } from '../services/fileService';
 import ConfirmationModal from './ConfirmationModal';
 import DocumentArchiveModal from './DocumentArchiveModal';
 import CreateFolderModal from './CreateFolderModal';
+import MoveFilesModal from './MoveFilesModal';
 
 interface DocumentManagerModalProps {
   isOpen: boolean;
@@ -35,6 +36,7 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
   const [showArchiveModal, setShowArchiveModal] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [showMoveModal, setShowMoveModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [currentPath, setCurrentPath] = useState('');
 
@@ -508,6 +510,14 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
           >
             <Folder size={20} />
           </button>
+          <button
+            className="move-folder-button"
+            onClick={() => setShowMoveModal(true)}
+            disabled={isLoading || selectedFiles.size === 0}
+            title="Move selected files to folder"
+          >
+            <FolderPlus size={20} />
+          </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}
             onDragOver={handleDragOver}
@@ -653,6 +663,14 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
           onClose={() => setShowFolderModal(false)}
           onCreate={confirmCreateFolder}
           isLoading={isCreatingFolder}
+        />
+        <MoveFilesModal
+          isOpen={showMoveModal}
+          onClose={() => setShowMoveModal(false)}
+          onMove={async (dest) => {
+            await moveSelectedFiles(dest);
+            setShowMoveModal(false);
+          }}
         />
       </div>
     </div>

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -5,6 +5,7 @@ import { fileService, FileInfo } from '../services/fileService';
 import ConfirmationModal from './ConfirmationModal';
 import DocumentArchiveModal from './DocumentArchiveModal';
 import CreateFolderModal from './CreateFolderModal';
+import MoveFilesModal from './MoveFilesModal';
 
 interface DocumentManagerPanelProps {
   onFileUpload: (file: File) => void;
@@ -24,6 +25,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
   const [showArchiveModal, setShowArchiveModal] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [showMoveModal, setShowMoveModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
 
   useEffect(() => {
@@ -450,6 +452,14 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           >
             <Folder size={20} />
           </button>
+          <button
+            className="move-folder-button"
+            onClick={() => setShowMoveModal(true)}
+            disabled={isLoading || selectedFiles.size === 0}
+            title="Move selected files to folder"
+          >
+            <FolderPlus size={20} />
+          </button>
           <div
             className={`drop-area ${isDragOver ? 'drag-over' : ''}`}
             onDragOver={handleDragOver}
@@ -589,6 +599,14 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           onClose={() => setShowFolderModal(false)}
           onCreate={confirmCreateFolder}
           isLoading={isCreatingFolder}
+        />
+        <MoveFilesModal
+          isOpen={showMoveModal}
+          onClose={() => setShowMoveModal(false)}
+          onMove={async (dest) => {
+            await moveSelectedFiles(dest);
+            setShowMoveModal(false);
+          }}
         />
       </div>
     </div>

--- a/src/components/MoveFilesModal.tsx
+++ b/src/components/MoveFilesModal.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Folder, X } from 'lucide-react';
+import { fileService } from '../services/fileService';
+
+interface MoveFilesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onMove: (destination: string) => void;
+}
+
+const MoveFilesModal: React.FC<MoveFilesModalProps> = ({ isOpen, onClose, onMove }) => {
+  const [folders, setFolders] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadFolders();
+    }
+  }, [isOpen]);
+
+  const loadFolders = async () => {
+    try {
+      setLoading(true);
+      const all = await fileService.listAllFolders();
+      setFolders(all);
+    } catch (error) {
+      console.error('Error loading folders:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-title-container">
+            <Folder size={24} />
+            <h2>Select Destination</h2>
+          </div>
+          <button onClick={onClose} className="modal-close-btn">
+            <X size={20} />
+          </button>
+        </div>
+        <div className="modal-body">
+          {loading ? (
+            <p>Loading folders...</p>
+          ) : (
+            <ul className="folder-list">
+              {folders.map((f) => (
+                <li key={f}>
+                  <button className="folder-choice" onClick={() => onMove(f)}>
+                    {f || '/'}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button onClick={onClose} className="btn btn-secondary">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MoveFilesModal;

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -141,6 +141,22 @@ class FileService {
     }
   }
 
+  /**
+   * Recursively list all folder paths in the workspace
+   */
+  async listAllFolders(path = ''): Promise<string[]> {
+    const items = await this.listFiles(path);
+    let folders: string[] = [];
+    for (const item of items) {
+      if (item.type === 'folder') {
+        folders.push(item.path);
+        const sub = await this.listAllFolders(item.path);
+        folders = folders.concat(sub);
+      }
+    }
+    return folders;
+  }
+
   async createFolder(folderName: string): Promise<void> {
     const response = await fetch(`${this.baseUrl}/files/create-folder`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- enable listing all folder paths in file service
- style and support for move-to-folder UI
- new MoveFilesModal for selecting folder
- hook modal into document manager panel and modal

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e9719768c832eadee9b5c033db1af