### PR TITLE
Add MoveFilesModal and folder listing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -467,6 +467,24 @@ def list_archived_files():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/files/folders", methods=["GET"])
+def list_all_folders():
+    """Recursively list all folder paths relative to the workspace"""
+    try:
+        folder_paths = [""]
+        for dirpath, dirnames, _ in os.walk(WORKSPACE_PATH):
+            if dirpath.startswith(ARCHIVE_PATH):
+                continue
+            rel_dir = os.path.relpath(dirpath, WORKSPACE_PATH)
+            if rel_dir != ".":
+                folder_paths.append(rel_dir.replace(os.sep, "/"))
+        folder_paths = sorted(set(folder_paths))
+        return jsonify({"folders": folder_paths})
+    except Exception as e:
+        logger.error(f"Error listing folders: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route("/files/create-folder", methods=["POST"])
 def create_folder():
     """Create a new folder inside the workspace directory"""

--- a/src/components/DocumentManagerModal.tsx
+++ b/src/components/DocumentManagerModal.tsx
@@ -5,6 +5,7 @@ import { fileService, FileInfo } from '../services/fileService';
 import ConfirmationModal from './ConfirmationModal';
 import DocumentArchiveModal from './DocumentArchiveModal';
 import CreateFolderModal from './CreateFolderModal';
+import MoveFilesModal from './MoveFilesModal';
 
 interface DocumentManagerModalProps {
   isOpen: boolean;
@@ -38,6 +39,7 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
   const [showArchiveModal, setShowArchiveModal] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [showMoveModal, setShowMoveModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [currentPath, setCurrentPath] = useState(
     initialPath ? (initialPath.endsWith('/') ? initialPath : `${initialPath}/`) : ''
@@ -518,9 +520,9 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
           </button>
           <button
             className="upload-button"
-            onClick={() => moveSelectedFiles('')}
+            onClick={() => setShowMoveModal(true)}
             disabled={isLoading || selectedFiles.size === 0}
-            title="Move selected files to main folder"
+            title="Move selected files"
           >
             <Folder size={20} />
           </button>
@@ -663,6 +665,11 @@ const DocumentManagerModal: React.FC<DocumentManagerModalProps> = ({
           onClose={() => setShowArchiveModal(false)}
           onFileUpload={onFileUpload}
           currentFile={currentFile}
+        />
+        <MoveFilesModal
+          isOpen={showMoveModal}
+          onClose={() => setShowMoveModal(false)}
+          onMove={(dest) => { setShowMoveModal(false); moveSelectedFiles(dest); }}
         />
         <CreateFolderModal
           isOpen={showFolderModal}

--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -6,6 +6,7 @@ import ConfirmationModal from './ConfirmationModal';
 import DocumentArchiveModal from './DocumentArchiveModal';
 import CreateFolderModal from './CreateFolderModal';
 import DocumentManagerModal from './DocumentManagerModal';
+import MoveFilesModal from './MoveFilesModal';
 
 interface DocumentManagerPanelProps {
   onFileUpload: (file: File) => void;
@@ -25,6 +26,7 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
   const [showArchiveModal, setShowArchiveModal] = useState(false);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [showFolderModal, setShowFolderModal] = useState(false);
+  const [showMoveModal, setShowMoveModal] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
   const [openFolderPath, setOpenFolderPath] = useState<string | null>(null);
 
@@ -446,9 +448,9 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           </button>
           <button
             className="upload-button"
-            onClick={() => moveSelectedFiles('')}
+            onClick={() => setShowMoveModal(true)}
             disabled={isLoading || selectedFiles.size === 0}
-            title="Move selected files to main folder"
+            title="Move selected files"
           >
             <Folder size={20} />
           </button>
@@ -602,6 +604,11 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
           onFileUpload={onFileUpload}
           currentFile={currentFile}
           initialPath={openFolderPath || ''}
+        />
+        <MoveFilesModal
+          isOpen={showMoveModal}
+          onClose={() => setShowMoveModal(false)}
+          onMove={(dest) => { setShowMoveModal(false); moveSelectedFiles(dest); }}
         />
         <CreateFolderModal
           isOpen={showFolderModal}

--- a/src/components/MoveFilesModal.tsx
+++ b/src/components/MoveFilesModal.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { Folder, X } from 'lucide-react';
+import { fileService } from '../services/fileService';
+
+interface MoveFilesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onMove: (destination: string) => void;
+}
+
+const MoveFilesModal: React.FC<MoveFilesModalProps> = ({ isOpen, onClose, onMove }) => {
+  const [folders, setFolders] = useState<string[]>([]);
+  const [destination, setDestination] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const fetchFolders = async () => {
+      try {
+        const list = await fileService.listFolders();
+        setFolders(list);
+      } catch (error) {
+        console.error('Error loading folders:', error);
+      }
+    };
+    fetchFolders();
+    setDestination('');
+  }, [isOpen]);
+
+  const handleMove = () => {
+    onMove(destination);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <div className="modal-title-container">
+            <Folder size={24} />
+            <h2>Move Files</h2>
+          </div>
+          <button onClick={onClose} className="modal-close-btn">
+            <X size={20} />
+          </button>
+        </div>
+        <div className="modal-body">
+          <select
+            className="search-input"
+            value={destination}
+            onChange={(e) => setDestination(e.target.value)}
+          >
+            {folders.map((f) => (
+              <option key={f} value={f}>
+                {f === '' ? 'Home' : f}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="modal-footer">
+          <button onClick={onClose} className="btn btn-secondary">
+            Cancel
+          </button>
+          <button onClick={handleMove} className="btn btn-primary" disabled={destination === undefined}>
+            Move
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MoveFilesModal;

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -154,6 +154,27 @@ class FileService {
     }
   }
 
+  async listFolders(): Promise<string[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/files/folders`);
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const errorMessage = data.error || `Server error: ${response.status} ${response.statusText}`;
+        throw new Error(errorMessage);
+      }
+
+      const data = await response.json();
+      return Array.isArray(data.folders) ? data.folders : [];
+    } catch (error) {
+      console.error('Error listing folders:', error);
+      if (error instanceof TypeError && error.message.includes('fetch')) {
+        throw new Error('Cannot connect to server. Please check if the backend is running.');
+      }
+      throw error;
+    }
+  }
+
   /**
    * Get list of archived files
    */


### PR DESCRIPTION
## Summary
- add backend API to list folder paths
- add `listFolders` to file service
- implement new `MoveFilesModal` for selecting a target folder
- hook move modal into document manager panel and modal

## Testing
- `npm test --silent --watchAll=false`
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e9ce54250832e9245e777a11689b4