### PR TITLE
Fix document list reload after moving files

### DIFF
--- a/src/components/DocumentManagerPanel.tsx
+++ b/src/components/DocumentManagerPanel.tsx
@@ -600,7 +600,10 @@ const DocumentManagerPanel: React.FC<DocumentManagerPanelProps> = ({ onFileUploa
         />
         <DocumentManagerModal
           isOpen={openFolderPath !== null}
-          onClose={() => setOpenFolderPath(null)}
+          onClose={() => {
+            setOpenFolderPath(null);
+            loadDocuments();
+          }}
           onFileUpload={onFileUpload}
           currentFile={currentFile}
           initialPath={openFolderPath || ''}


### PR DESCRIPTION
## Summary
- refresh document list when closing folder modal after moving files

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea3d1e2f8832e8d1c23bac6bf47e8