### PR TITLE
Enable page navigation in translation modal

### DIFF
--- a/src/components/TranslationModal.tsx
+++ b/src/components/TranslationModal.tsx
@@ -24,6 +24,8 @@ interface TranslationModalProps {
   saving?: boolean;
   error?: string;
   onSendToChat?: (text: string) => void;
+  onPrevPage?: () => void;
+  onNextPage?: () => void;
 }
 
 const TranslationModal: React.FC<TranslationModalProps> = ({
@@ -44,7 +46,9 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
   success = '',
   saving = false,
   error = '',
-  onSendToChat
+  onSendToChat,
+  onPrevPage,
+  onNextPage
 }) => {
   const [selectedText, setSelectedText] = useState<string>('');
   const [modalAnnotation, setModalAnnotation] = useState<string>(annotation);
@@ -390,7 +394,21 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
         </div>
         
         <div className="translation-modal-actions">
-          <button 
+          {(onPrevPage || onNextPage) && (
+            <div style={{ marginRight: 'auto', display: 'flex', gap: '8px' }}>
+              {onPrevPage && (
+                <button className="btn btn-secondary" onClick={onPrevPage} disabled={isStreaming || saving}>
+                  Previous Page
+                </button>
+              )}
+              {onNextPage && (
+                <button className="btn btn-secondary" onClick={onNextPage} disabled={isStreaming || saving}>
+                  Next Page
+                </button>
+              )}
+            </div>
+          )}
+          <button
             className="btn btn-primary"
             onClick={handleAddEverything}
             disabled={isStreaming || saving}

--- a/src/utils/pdfUtils.ts
+++ b/src/utils/pdfUtils.ts
@@ -1,0 +1,17 @@
+import { pdfjs } from 'react-pdf';
+
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
+
+export async function extractPageText(file: File, pageNumber: number): Promise<string> {
+  const loadingTask = pdfjs.getDocument(URL.createObjectURL(file));
+  const pdf = await loadingTask.promise;
+  const page = await pdf.getPage(pageNumber);
+  const textContent = await page.getTextContent();
+  return textContent.items.map((item: any) => item.str).join(' ').trim();
+}
+
+export async function getNumPages(file: File): Promise<number> {
+  const loadingTask = pdfjs.getDocument(URL.createObjectURL(file));
+  const pdf = await loadingTask.promise;
+  return pdf.numPages;
+}


### PR DESCRIPTION
## Summary
- add utilities to extract PDF page text and page count
- expose numPages to App via PDFViewer
- enable auto-translation when navigating pages in TranslationModal
- hook up previous/next page buttons in modal actions

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e952badf4832eab75d72a180888a5