### PR TITLE
Switch translation modal actions to icon buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -372,7 +372,7 @@
   padding: 16px 20px; /* Adjusted padding */
   border-top: 1px solid #eeeeee; /* Lighter border */
   background: #fcfcfc; /* Very light gray for footer */
-  justify-content: flex-end;
+  justify-content: center;
   flex-shrink: 0;
 }
 
@@ -482,6 +482,24 @@
   transform: none;
   background-color: #f0f0f0;
   border-color: #dddddd;
+}
+
+/* Icon buttons for translation modal */
+.modal-icon-btn {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 768px) {
+  .modal-icon-btn {
+    width: 44px;
+    height: 44px;
+  }
 }
 
 @keyframes pulse {

--- a/src/components/TranslationModal.tsx
+++ b/src/components/TranslationModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
-import { MessageCircle } from 'lucide-react';
+import { MessageCircle, PlusCircle, CheckCircle, ArrowLeftCircle, ChevronLeft, ChevronRight } from 'lucide-react';
 import { TranslationConfig } from '../types';
 import SuccessMessage from './SuccessMessage';
 
@@ -395,44 +395,61 @@ const TranslationModal: React.FC<TranslationModalProps> = ({
         
         <div className="translation-modal-actions">
           {(onPrevPage || onNextPage) && (
-            <div style={{ marginRight: 'auto', display: 'flex', gap: '8px' }}>
+            <div style={{ display: 'flex', gap: '8px' }}>
               {onPrevPage && (
-                <button className="btn btn-secondary" onClick={onPrevPage} disabled={isStreaming || saving}>
-                  Previous Page
+                <button
+                  className="btn btn-secondary modal-icon-btn"
+                  onClick={onPrevPage}
+                  disabled={isStreaming || saving}
+                  aria-label="Previous page"
+                >
+                  <ChevronLeft size={24} />
                 </button>
               )}
               {onNextPage && (
-                <button className="btn btn-secondary" onClick={onNextPage} disabled={isStreaming || saving}>
-                  Next Page
+                <button
+                  className="btn btn-secondary modal-icon-btn"
+                  onClick={onNextPage}
+                  disabled={isStreaming || saving}
+                  aria-label="Next page"
+                >
+                  <ChevronRight size={24} />
                 </button>
               )}
             </div>
           )}
           <button
-            className="btn btn-primary"
+            className="btn btn-primary modal-icon-btn"
             onClick={handleAddEverything}
             disabled={isStreaming || saving}
+            aria-label="Add everything"
           >
-            {saving ? 'Saving...' : 'Add Everything'}
+            {saving ? <span>...</span> : <PlusCircle size={24} />}
           </button>
           <button
-            className="btn btn-secondary"
+            className="btn btn-secondary modal-icon-btn"
             onClick={handleAddSelection}
             disabled={!selectedText.trim() || isStreaming || saving}
+            aria-label="Add selection"
           >
-            {saving ? 'Saving...' : 'Add Selection'}
+            {saving ? <span>...</span> : <CheckCircle size={24} />}
           </button>
           {onSendToChat && (
-            <button className="btn btn-chat" onClick={handleSendToChat} disabled={isStreaming || saving}>
-              <MessageCircle size={16} />
-              <span style={{ marginLeft: '4px' }}>Send to chat</span>
+            <button
+              className="btn btn-chat modal-icon-btn"
+              onClick={handleSendToChat}
+              disabled={isStreaming || saving}
+              aria-label="Send to chat"
+            >
+              <MessageCircle size={24} />
             </button>
           )}
           <button
-            className="btn btn-tertiary"
+            className="btn btn-tertiary modal-icon-btn"
             onClick={handleClose}
+            aria-label="Return"
           >
-            Return
+            <ArrowLeftCircle size={24} />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- center translation modal footer actions
- add circular icon button style
- replace textual buttons with icons in TranslationModal

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68551e5824f0832ebedefe62c9cb0d3b