### PR TITLE
Fix persistent storage for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,15 @@ If you're unfamiliar with GitHub:
    ```sh
    docker-compose up --build
    ```
-5. The first run creates `data` and `myworkspace` folders beside `docker-compose.yml`. Your configuration lives inside `data` so it persists when updating the container.
+5. On first run Docker creates persistent volumes named `data` and `workspace`. Your configuration in these volumes will remain when updating the container.
 6. Wait for the server to start, then open [http://localhost:5026](http://localhost:5026).
 
-If you prefer `docker run`, mount the same folders:
+If you prefer `docker run`, mount the same volumes:
 ```sh
 docker run -d \
   -p 5026:5026 \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/myworkspace:/myworkspace \
+  -v notypdf_data:/app/data \
+  -v notypdf_workspace:/myworkspace \
   --name notypdf drakonis96/notypdf:latest
 ```
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,8 +13,8 @@ services:
       - NOTION_API_KEY=${NOTION_API_KEY}
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./data:/app/data
-      - ./myworkspace:/myworkspace
+      - data:/app/data
+      - workspace:/myworkspace
     restart: unless-stopped
     networks:
       - default
@@ -22,3 +22,7 @@ services:
 networks:
   default:
     name: pdf-reader-network
+
+volumes:
+  data:
+  workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY}
       - NOTION_API_KEY=${NOTION_API_KEY}
     volumes:
-      - ./data:/app/data
-      - ./myworkspace:/myworkspace
+      - data:/app/data
+      - workspace:/myworkspace
     restart: unless-stopped
     networks:
       - default
@@ -21,3 +21,7 @@ services:
 networks:
   default:
     name: pdf-reader-network
+
+volumes:
+  data:
+  workspace:


### PR DESCRIPTION
## Summary
- persist configuration using named Docker volumes
- document persistent volumes in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ef300f68832eb96aee16a66f01f8