### PR TITLE
Allow custom translation prompts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,9 @@ export interface TranslationConfig {
   model: TranslationModel;
   targetLanguage: string;
   sendMode: 'original' | 'translated';
+  prompts: string[];
+  promptIndex: number;
+  showSelectionModal?: boolean;
 }
 
 export interface TagMapping {
@@ -68,6 +71,8 @@ export interface AppConfig {
   savedDatabaseIds: SavedDatabaseId[];
   columnMappings: Record<string, Partial<NotionConfig>>;
   tagMappings?: Record<string, TagMapping>;
+  translationPrompts?: string[];
+  selectedTranslationPromptIndex?: number;
   bookmarks?: Record<string, number>;
   lastUpdated: string;
 }

--- a/src/utils/pdfUtils.ts
+++ b/src/utils/pdfUtils.ts
@@ -15,3 +15,20 @@ export async function getNumPages(file: File): Promise<number> {
   const pdf = await loadingTask.promise;
   return pdf.numPages;
 }
+
+export async function renderPageToImage(
+  file: File,
+  pageNumber: number,
+  scale = 2
+): Promise<string> {
+  const loadingTask = pdfjs.getDocument(URL.createObjectURL(file));
+  const pdf = await loadingTask.promise;
+  const page = await pdf.getPage(pageNumber);
+  const viewport = page.getViewport({ scale });
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d');
+  canvas.width = viewport.width;
+  canvas.height = viewport.height;
+  await page.render({ canvasContext: context!, viewport }).promise;
+  return canvas.toDataURL('image/png');
+}


### PR DESCRIPTION
## Summary
- support editable translation prompts in config
- persist selected prompt and list server-side
- update translation service to accept custom prompt templates
- expose prompt editing controls in translation options
- add toggle to show selection modal or auto-copy text
- keep translate button visible
- implement full page translation using OCR

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fe6a2620832e873494af04ae3e3a